### PR TITLE
Fix missing entity validation in config flow

### DIFF
--- a/custom_components/pumpsteer/config_flow.py
+++ b/custom_components/pumpsteer/config_flow.py
@@ -88,11 +88,11 @@ class PumpSteerConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         for field in user_selected_entities:
             entity_id = user_input.get(field)
             if not entity_id:
-                errors[field] = f"Required: {description}"
+                errors[field] = "required"
                 continue
 
             if not await self._entity_exists(entity_id):
-                errors[field] = "required"
+                errors[field] = "entity_not_found"
             elif not await self._entity_available(entity_id):
                 errors[field] = "entity_unavailable"
 


### PR DESCRIPTION
## Summary
- ensure missing user-selected entities raise a proper `required` error
- report `entity_not_found` when selected entities do not exist

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68988333e3ac832e89c0a56a74eb6194