### PR TITLE
Update config_flow.py

### DIFF
--- a/custom_components/pumpsteer/config_flow.py
+++ b/custom_components/pumpsteer/config_flow.py
@@ -131,4 +131,4 @@ class PumpSteerConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     @callback
     def async_get_options_flow(config_entry):
         """Get the options flow for this handler."""
-        return PumpSteerOptionsFlowHandler(config_entry)
+        return PumpSteerOptionsFlowHandler()


### PR DESCRIPTION
Fix: Update options flow for Home Assistant 2025.12 compatibility

- Remove deprecated config_entry parameter from OptionsFlowHandler.__init__()
- Utilize new automatic config_entry property from OptionsFlow base class
- Simplify entry access using self.config_entry instead of manual lookup
- Update async_get_options_flow to return handler without config_entry argument
- Fix syntax error caused by smart quotes in DOMAIN constant

This resolves the deprecation warning:
"custom integration 'pumpsteer' sets option flow config_entry explicitly,  which is deprecated and will stop working in Home Assistant 2025.12"

Follows the new OptionsFlow pattern as documented in: https://developers.home-assistant.io/blog/2024/11/12/options-flow/