### PR TITLE
docs: document preboost and price model helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ I'm not an expert in programming, energy systems, or automation. This setup is b
 * 🧊 Braking mode: limits heating during high prices
 * ☀️ Summer mode: disables heating control during warm weather
 * 🏝️ Holiday mode: temporarily reduces temperature when away
+* 🚀 Pre-boost: stores heat before cold or high-price periods
+* 📈 Switchable price model (`hybrid` or `percentiles`)
 * 🤖 ML analysis: learns how your house responds (session-based)
 * 🔁 Auto-adjustment of `house_inertia` (if enabled)
 * 🧠 Recommendations for improved comfort/savings balance
@@ -68,6 +70,8 @@ If PumpSteer is not yet available in HACS:
 | `input_text`     | `hourly_forecast_temperatures`  | Temperature forecast (24 CSV values)    |
 | `input_boolean`  | `holiday_mode`                  | Activates holiday mode                  |
 | `input_boolean`  | `autotune_inertia`              | Allow system to adjust `house_inertia`  |
+| `input_boolean`  | `pumpsteer_preboost_enabled`    | Enable pre-boost before cold/expensive periods |
+| `input_select`   | `pumpsteer_price_model`         | Price classification model (`hybrid` or `percentiles`) |
 | `input_datetime` | `holiday_start` / `holiday_end` | Automatically enable holiday mode       |
 
 ---
@@ -119,6 +123,7 @@ Virtual (fake) outdoor temperature sent to your heat pump.
 | `Decision Reason`            | Reason for current decision                         |
 | `Price Categories All Hours` | Classification for all hours                        |
 | `Current Hour`               | Current hour of the day                             |
+| `Preboost Enabled`           | Whether pre-boost mode is allowed                   |
 | `Data Quality`               | Availability and completeness of input data         |
 
 ---


### PR DESCRIPTION
## Summary
- document pre-boost heating and selectable price model in README
- describe new helper entities and sensor attribute

## Testing
- `pytest` *(fails: No module named 'homeassistant')*


------
https://chatgpt.com/codex/tasks/task_e_689cc7b3bdc8832ead8d31634ba0ce42