### PR TITLE
feat: push target temp when prices are cheap

### DIFF
--- a/custom_components/pumpsteer/settings.py
+++ b/custom_components/pumpsteer/settings.py
@@ -30,6 +30,8 @@ PREBOOST_MAX_OUTDOOR_TEMP: Final[float] = (
 MIN_FAKE_TEMP: Final[float] = -25.0
 MAX_FAKE_TEMP: Final[float] = 30.0
 BRAKE_FAKE_TEMP: Final[float] = 25.0
+WINTER_BRAKE_TEMP_OFFSET: Final[float] = 7.0  # °C offset above outdoor temp when braking in winter
+CHEAP_PRICE_OVERSHOOT: Final[float] = 1.0  # °C to overshoot target when prices are cheap
 
 # === ELECTRICITY PRICE CLASSIFICATION ===
 DEFAULT_PERCENTILES: Final[List[int]] = [

--- a/custom_components/pumpsteer/temp_control_logic.py
+++ b/custom_components/pumpsteer/temp_control_logic.py
@@ -3,7 +3,6 @@ import logging
 from .settings import (
     MIN_FAKE_TEMP,
     MAX_FAKE_TEMP,
-    BRAKE_FAKE_TEMP,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -14,6 +13,7 @@ def calculate_temperature_output(
     actual_target_temp_for_logic: float,
     real_outdoor_temp: float,
     aggressiveness: float,
+    brake_temp: float,
 ) -> tuple[float, str]:
     """
     Calculates the virtual outdoor temperature (fake_temp) and operating mode
@@ -82,7 +82,7 @@ def calculate_temperature_output(
     # The fake temperature is increased to make the heat pump work less (or cool).
     elif diff > 0.5:
         fake_temp = real_outdoor_temp + (diff * scaling_factor * 4)
-        fake_temp = max(min(fake_temp, MAX_FAKE_TEMP), BRAKE_FAKE_TEMP)
+        fake_temp = max(min(fake_temp, MAX_FAKE_TEMP), brake_temp)
         mode = "braking_by_temp"
         _LOGGER.debug(
             f"TempControl: Braking (fake temp: {fake_temp:.1f} °C, diff: {diff:.2f}, agg: {aggressiveness}) - Mode: {mode}"

--- a/tests/test_temperature_vs_price.py
+++ b/tests/test_temperature_vs_price.py
@@ -52,4 +52,20 @@ def test_price_brake_when_neutral():
     data = base_sensor_data()
     fake_temp, mode = s._calculate_output_temperature(data, [], "expensive", 0)
     assert mode == "braking_by_price"
-    assert fake_temp == sensor.BRAKING_MODE_TEMP
+    assert fake_temp == data["outdoor_temp"] + sensor.WINTER_BRAKE_TEMP_OFFSET
+
+
+def test_very_cheap_price_overshoots_target():
+    s = create_sensor()
+    data = base_sensor_data()
+    fake_temp, mode = s._calculate_output_temperature(data, [], "very_cheap", 0)
+    assert mode == "heating"
+    assert fake_temp < data["outdoor_temp"]
+
+
+def test_cheap_price_overshoots_target():
+    s = create_sensor()
+    data = base_sensor_data()
+    fake_temp, mode = s._calculate_output_temperature(data, [], "cheap", 0)
+    assert mode == "heating"
+    assert fake_temp < data["outdoor_temp"]


### PR DESCRIPTION
## Summary
- Overshoot target temperature when price category is cheap or very cheap
- Update constant description for cheap-price overshoot
- Test cheap price overshoot behavior

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a8758bfd1c832e9c0ea444493d4669