### PR TITLE
Limit overshoot to very cheap price levels

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,7 +181,7 @@ Recommendations can be shown in UI or in markdown cards.
 
 PumpSteer controls your heat pump's perceived demand using a fake outdoor temperature:
 
-* Increases heating when electricity is cheap
+* Slightly increases heating (1 °C overshoot) only when electricity prices are very cheap
 * Avoids heating when prices are high
 * Goes to neutral mode when stable
 * Disables heating when it's warm outside (summer mode)

--- a/custom_components/pumpsteer/sensor/sensor.py
+++ b/custom_components/pumpsteer/sensor/sensor.py
@@ -292,9 +292,9 @@ class PumpSteerSensor(Entity):
         if outdoor_temp >= summer_threshold:
             return outdoor_temp, "summer_mode"
 
-        # Allow slight overshoot when prices are cheap or very cheap
+        # Allow slight overshoot only when prices are very cheap
         target_temp_for_logic = target_temp
-        if "very_cheap" in price_category or "cheap" in price_category:
+        if "very_cheap" in price_category:
             target_temp_for_logic += CHEAP_PRICE_OVERSHOOT
 
         # Dynamic braking temperature based on outdoor temp

--- a/custom_components/pumpsteer/settings.py
+++ b/custom_components/pumpsteer/settings.py
@@ -31,7 +31,7 @@ MIN_FAKE_TEMP: Final[float] = -25.0
 MAX_FAKE_TEMP: Final[float] = 30.0
 BRAKE_FAKE_TEMP: Final[float] = 25.0
 WINTER_BRAKE_TEMP_OFFSET: Final[float] = 7.0  # °C offset above outdoor temp when braking in winter
-CHEAP_PRICE_OVERSHOOT: Final[float] = 1.0  # °C to overshoot target when prices are cheap
+CHEAP_PRICE_OVERSHOOT: Final[float] = 1.0  # °C to overshoot target when prices are very cheap
 
 # === ELECTRICITY PRICE CLASSIFICATION ===
 DEFAULT_PERCENTILES: Final[List[int]] = [

--- a/tests/test_temperature_vs_price.py
+++ b/tests/test_temperature_vs_price.py
@@ -63,9 +63,9 @@ def test_very_cheap_price_overshoots_target():
     assert fake_temp < data["outdoor_temp"]
 
 
-def test_cheap_price_overshoots_target():
+def test_cheap_price_neutral_behavior():
     s = create_sensor()
     data = base_sensor_data()
     fake_temp, mode = s._calculate_output_temperature(data, [], "cheap", 0)
-    assert mode == "heating"
-    assert fake_temp < data["outdoor_temp"]
+    assert mode == "neutral"
+    assert fake_temp == data["outdoor_temp"]


### PR DESCRIPTION
## Summary
- Only apply 1 °C target overshoot when price category is `very_cheap`
- Cheap price category now yields neutral behavior with updated tests
- Documentation adjusted to mention overshoot only for very cheap prices

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68aac1e8a7b4832e92e12fadffc3df9d