### PR TITLE
Handle braking when electricity price extreme

### DIFF
--- a/custom_components/pumpsteer/sensor/sensor.py
+++ b/custom_components/pumpsteer/sensor/sensor.py
@@ -323,7 +323,9 @@ class PumpSteerSensor(Entity):
                 fake_temp, mode = outdoor_temp, "error"
 
         if mode not in ["braking_by_temp", "heating"] and (
-            "expensive" in price_category or "very_expensive" in price_category
+            "expensive" in price_category
+            or "very_expensive" in price_category
+            or "extreme" in price_category
         ):
             price_brake_temp = (
                 outdoor_temp + WINTER_BRAKE_TEMP_OFFSET

--- a/tests/test_temperature_vs_price.py
+++ b/tests/test_temperature_vs_price.py
@@ -61,6 +61,14 @@ def test_price_brake_when_neutral():
     assert fake_temp == data["outdoor_temp"] + sensor.WINTER_BRAKE_TEMP_OFFSET
 
 
+def test_extreme_price_brake_when_neutral():
+    s = create_sensor()
+    data = base_sensor_data()
+    fake_temp, mode = s._calculate_output_temperature(data, [], "extreme", 0)
+    assert mode == "braking_by_price"
+    assert fake_temp == data["outdoor_temp"] + sensor.WINTER_BRAKE_TEMP_OFFSET
+
+
 def test_very_cheap_price_overshoots_target():
     s = create_sensor()
     data = base_sensor_data()


### PR DESCRIPTION
## Summary
- brake heating output when price category is extreme
- test extreme price category braking behavior

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68ad43727a54832e85499ab286b8d52c