### PR TITLE
Update to new badge for temperature forecast blueprint import

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,8 +70,7 @@ If PumpSteer is not yet available in HACS:
 
 PumpSteer requires hourly temperature forecasts in `input_text.hourly_forecast_temperatures`. Instead of manual entry, use our automated blueprint:
 
-[![Import Blueprint](https://img.shields.io/badge/IMPORT%20BLUEPRINT%20TO-MY%20🏠-41BDF5?style=for-the-badge&labelColor=54B4D3)](https://my.home-assistant.io/redirect/blueprint_import/?blueprint_url=[https%3A//gist.githubusercontent.com/JohanAlvedal/48fb8b3e1ef5fc3a70b5c473be54e2fe/raw](https://gist.github.com/JohanAlvedal/48fb8b3e1ef5fc3a70b5c473be54e2fe.js))
-
+[![Open your Home Assistant instance and show the blueprint import dialog with a specific blueprint pre-filled.](https://my.home-assistant.io/badges/blueprint_import.svg)](https://my.home-assistant.io/redirect/blueprint_import/?blueprint_url=https%3A%2F%2Fgist.githubusercontent.com%2FJohanAlvedal%2F48fb8b3e1ef5fc3a70b5c473be54e2fe%2Fraw%2Fpumpsteer_temperature_forcast.yaml)
 
 ### What it does:
 - 🔄 Automatically fetches 24-hour temperature forecasts


### PR DESCRIPTION
_Well done on this component! Started using it today and hit a few bumps as I went along. I'll create PRs for them when I've got time over, you decide what to do with them. Starting it easy, because I like the style of the new badges 🙂_

This PR updates the badge style for blueprint importing to the more recent one from Home Assistant. It also ensures we point at the correct file in the gist, if you were ever to add more to it. When new revisions of the gist are created, I think it'll always point at the newest one.

<table border="1">
  <tr>
    <th>Old</th>
    <th>New</th>
  </tr>
  <tr>
    <td><img width="266" height="68" alt="image" src="https://github.com/user-attachments/assets/30c0cd41-5f45-4e58-8b96-c10b75c646b5" /></td>
    <td><img width="330" height="79" alt="image" src="https://github.com/user-attachments/assets/640503de-b3cc-48f0-9372-70fd2bf70ed4" /></td>
  </tr>
</table>