### PR TITLE
Remove sensor unrelated to PumpSteer from lovelace examples

### DIFF
--- a/other/pumpsteer_cards_for_lovelace
+++ b/other/pumpsteer_cards_for_lovelace
@@ -18,7 +18,6 @@ entities:
     name: Broms aktiv
     secondary_info: last-changed
   - type: divider
-  - entity: sensor.atc_fe8e_temperature
   - entity: sensor.real_outdoor_temperature
     name: Outdoor
     secondary_info: last-changed


### PR DESCRIPTION
Mini PR removing a sensor I think you might have locally, but that's not from PumpSteer.