### PR TITLE
refactor: centralize version retrieval

### DIFF
--- a/custom_components/pumpsteer/sensor/ml_sensor.py
+++ b/custom_components/pumpsteer/sensor/ml_sensor.py
@@ -1,8 +1,6 @@
 # ml_sensor.py – Improved ML analysis sensor for PumpSteer
 
 import logging
-import json
-from pathlib import Path
 from typing import Dict, Any
 from homeassistant.core import HomeAssistant
 from homeassistant.config_entries import ConfigEntry
@@ -13,21 +11,12 @@ from homeassistant.helpers.device_registry import DeviceInfo
 import homeassistant.util.dt as dt_util
 
 from ..ml_adaptive import PumpSteerMLCollector
-from ..utils import safe_float, get_state
+from ..utils import safe_float, get_state, get_version
 
 _LOGGER = logging.getLogger(__name__)
 
 
-def _get_version() -> str:
-    manifest_path = Path(__file__).resolve().parents[1] / "manifest.json"
-    try:
-        with open(manifest_path) as manifest_file:
-            return json.load(manifest_file).get("version", "1.3.4")
-    except FileNotFoundError:
-        return "1.3.4"
-
-
-SW_VERSION = _get_version()
+SW_VERSION = get_version()
 
 # Important ML-related entities - these are critical for PumpSteer control
 ML_RELATED_ENTITIES = {

--- a/custom_components/pumpsteer/sensor/sensor.py
+++ b/custom_components/pumpsteer/sensor/sensor.py
@@ -1,8 +1,6 @@
 # sensor.py
 
 import logging
-import json
-from pathlib import Path
 from typing import Optional, Dict, Any, Tuple, List
 
 from homeassistant.config_entries import ConfigEntry
@@ -35,6 +33,7 @@ from ..utils import (
     get_state,
     get_attr,
     safe_array_slice,
+    get_version,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -52,16 +51,7 @@ except ImportError as e:
 DOMAIN = "pumpsteer"
 
 
-def _get_version() -> str:
-    manifest_path = Path(__file__).resolve().parents[1] / "manifest.json"
-    try:
-        with open(manifest_path) as manifest_file:
-            return json.load(manifest_file).get("version", "1.3.4")
-    except FileNotFoundError:
-        return "1.3.4"
-
-
-SW_VERSION = _get_version()
+SW_VERSION = get_version()
 
 # Hardcoded entities
 HARDCODED_ENTITIES = {

--- a/custom_components/pumpsteer/utils.py
+++ b/custom_components/pumpsteer/utils.py
@@ -1,4 +1,6 @@
 import logging
+import json
+from pathlib import Path
 from typing import Optional, Tuple, List, Any, Union
 from homeassistant.core import HomeAssistant
 from homeassistant.const import STATE_UNAVAILABLE, STATE_UNKNOWN
@@ -12,6 +14,16 @@ from .settings import (
 )
 
 _LOGGER = logging.getLogger(__name__)
+
+
+def get_version() -> str:
+    """Load integration version from manifest.json."""
+    manifest_path = Path(__file__).resolve().parents[1] / "manifest.json"
+    try:
+        with open(manifest_path) as manifest_file:
+            return json.load(manifest_file).get("version", "1.3.4")
+    except FileNotFoundError:
+        return "1.3.4"
 
 
 def safe_float(


### PR DESCRIPTION
## Summary
- add `get_version` helper to load version from manifest
- use shared `get_version` in sensors instead of local helpers

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b18f5897bc832e8bb369c18999a705