### PR TITLE
Add ML collector shutdown on sensor removal

### DIFF
--- a/custom_components/pumpsteer/ml_adaptive.py
+++ b/custom_components/pumpsteer/ml_adaptive.py
@@ -170,6 +170,16 @@ class PumpSteerMLCollector:
         with open(self.data_file, "w") as f:
             json.dump(data, f, indent=2)
 
+    async def async_shutdown(self) -> None:
+        """Flush pending data and release resources."""
+        try:
+            if self.current_session is not None:
+                # Ensure any active session is closed before shutdown
+                self.end_session("shutdown")
+            await self.async_save_data()
+        except Exception as e:
+            _LOGGER.error(f"ML: Error during shutdown: {e}")
+
     def start_session(self, initial_data: Dict[str, Any]) -> None:
         """Start a new learning session."""
         if self.current_session is not None:

--- a/custom_components/pumpsteer/sensor/ml_sensor.py
+++ b/custom_components/pumpsteer/sensor/ml_sensor.py
@@ -115,6 +115,16 @@ class PumpSteerMLSensor(Entity):
                 _LOGGER.error(f"ML sensor: Failed to load data: {e}")
                 self._last_error = f"Data loading failed: {e}"
 
+    async def async_will_remove_from_hass(self) -> None:
+        """Handle cleanup when entity is removed."""
+        if self.ml and hasattr(self.ml, "async_shutdown"):
+            try:
+                await self.ml.async_shutdown()
+            except Exception as e:
+                _LOGGER.error(f"ML sensor: Error during shutdown: {e}")
+        self.ml = None
+        await super().async_will_remove_from_hass()
+
     def _get_control_system_data(self) -> Dict[str, Any]:
         """Get data from Home Assistant control system entities."""
         try:

--- a/custom_components/pumpsteer/sensor/sensor.py
+++ b/custom_components/pumpsteer/sensor/sensor.py
@@ -199,6 +199,16 @@ class PumpSteerSensor(Entity):
 
         await super().async_added_to_hass()
 
+    async def async_will_remove_from_hass(self) -> None:
+        """Handle entity removal from Home Assistant."""
+        if self.ml_collector and hasattr(self.ml_collector, "async_shutdown"):
+            try:
+                await self.ml_collector.async_shutdown()
+            except Exception as e:
+                _LOGGER.error(f"Error during ML collector shutdown: {e}")
+        self.ml_collector = None
+        await super().async_will_remove_from_hass()
+
 
     async def async_options_update_listener(self, hass: HomeAssistant, entry: ConfigEntry) -> None:
         """Handle options update event."""


### PR DESCRIPTION
## Summary
- add async_shutdown to PumpSteerMLCollector to flush sessions
- clean up ML collector in PumpSteerSensor and PumpSteerMLSensor when removed from Home Assistant

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b194774954832e8c6a820ceb44ff67