### PR TITLE
Handle missing manifest in version retrieval

### DIFF
--- a/custom_components/pumpsteer/utils.py
+++ b/custom_components/pumpsteer/utils.py
@@ -18,12 +18,23 @@ _LOGGER = logging.getLogger(__name__)
 
 def get_version() -> str:
     """Load integration version from manifest.json."""
-    manifest_path = Path(__file__).resolve().parents[1] / "manifest.json"
+    manifest_path = Path(__file__).resolve().parent / "manifest.json"
     try:
         with open(manifest_path) as manifest_file:
-            return json.load(manifest_file).get("version", "1.3.4")
+            data = json.load(manifest_file)
     except FileNotFoundError:
-        return "1.3.4"
+        _LOGGER.error("manifest.json not found at %s", manifest_path)
+        return "unknown"
+    except json.JSONDecodeError as err:
+        _LOGGER.error("Error decoding manifest.json: %s", err)
+        return "unknown"
+
+    version = data.get("version")
+    if not version:
+        _LOGGER.error("Version not set in manifest.json")
+        return "unknown"
+
+    return version
 
 
 def safe_float(

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,13 @@
+import builtins
+from custom_components.pumpsteer.utils import get_version
+
+
+def test_get_version_reads_manifest():
+    assert get_version() == "1.4.9-beta"
+
+
+def test_get_version_missing_manifest(monkeypatch):
+    def fake_open(*args, **kwargs):
+        raise FileNotFoundError
+    monkeypatch.setattr(builtins, "open", fake_open)
+    assert get_version() == "unknown"


### PR DESCRIPTION
## Summary
- Read integration version directly from manifest.json and log errors when missing or invalid instead of returning a hardcoded fallback
- Add tests covering successful version retrieval and missing manifest cases

## Testing
- `pytest -q`
- `pip install pyflakes` *(fails: Cannot connect to proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68b30ff51c94832eb7b94ef23fd87a4d