### PR TITLE
Use async_create_task for session save

### DIFF
--- a/custom_components/pumpsteer/ml_adaptive.py
+++ b/custom_components/pumpsteer/ml_adaptive.py
@@ -231,8 +231,8 @@ class PumpSteerMLCollector:
         self.learning_sessions.append(self.current_session)
         self.current_session = None
 
-        # Save to file asynchronously
-        self.hass.loop.create_task(self.async_save_data())
+        # Save to file asynchronously using Home Assistant helper
+        self.hass.async_create_task(self.async_save_data())
 
         if ML_LOG_SESSION_DETAILS:
             _LOGGER.debug(
@@ -832,8 +832,8 @@ class PumpSteerMLCollector:
         self.learning_sessions.append(self.current_session)
         self.current_session = None
 
-        # Save to file asynchronously
-        self.hass.loop.create_task(self.async_save_data())
+        # Save to file asynchronously using Home Assistant helper
+        self.hass.async_create_task(self.async_save_data())
 
         _LOGGER.debug(
             f"ML: Session ended - Reason: {reason}, Duration: {session_summary.get('duration_minutes', 0):.1f}min"


### PR DESCRIPTION
## Summary
- use `hass.async_create_task` in `end_session` to schedule saving session data

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b58bc0652c832eb07c7b54e4932921