### PR TITLE
Add summer precooling based on forecast

### DIFF
--- a/custom_components/pumpsteer/settings.py
+++ b/custom_components/pumpsteer/settings.py
@@ -30,6 +30,7 @@ PREBOOST_MAX_OUTDOOR_TEMP: Final[float] = (
 MIN_FAKE_TEMP: Final[float] = -25.0
 MAX_FAKE_TEMP: Final[float] = 30.0
 BRAKE_FAKE_TEMP: Final[float] = 25.0
+SUMMER_PRECOOL_LOOKAHEAD: Final[int] = 6  # Hours ahead to look for summer precooling
 WINTER_BRAKE_TEMP_OFFSET: Final[float] = 10.0  # °C offset above outdoor temp when braking in winter
 CHEAP_PRICE_OVERSHOOT: Final[float] = 1.5  # °C to overshoot target when prices are very cheap
 HEATING_COMPENSATION_FACTOR: Final[float] = (

--- a/custom_components/pumpsteer/utils.py
+++ b/custom_components/pumpsteer/utils.py
@@ -306,6 +306,24 @@ def safe_parse_temperature_forecast(
         return None
 
 
+def should_precool_for_summer(
+    temp_forecast_csv: Optional[str],
+    summer_threshold: float,
+    lookahead_hours: int,
+) -> bool:
+    """Check if forecast exceeds summer threshold within given hours."""
+    if not temp_forecast_csv:
+        return False
+
+    temps = safe_parse_temperature_forecast(
+        temp_forecast_csv, max_hours=lookahead_hours
+    )
+    if not temps:
+        return False
+
+    return any(t >= summer_threshold for t in temps)
+
+
 def validate_required_entities(
     hass: HomeAssistant, config: dict, strict: bool = True
 ) -> List[str]:


### PR DESCRIPTION
## Summary
- precool before summer temperatures based on forecast
- support new `should_precool_for_summer` helper
- test summer precool behavior

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b6f2267ef0832e82fb44209445e25d