### PR TITLE
Rename precool_for_summer mode to precool

### DIFF
--- a/custom_components/pumpsteer/sensor/sensor.py
+++ b/custom_components/pumpsteer/sensor/sensor.py
@@ -35,7 +35,7 @@ from ..utils import (
     get_attr,
     safe_array_slice,
     get_version,
-    should_precool_for_summer,
+    should_precool,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -296,13 +296,13 @@ class PumpSteerSensor(Entity):
             _LOGGER.info(f"Pre-boost activated. Setting fake temp to {PREBOOST_OUTPUT_TEMP} °C")
             return PREBOOST_OUTPUT_TEMP, "preboost"
 
-        if temp_forecast_csv and should_precool_for_summer(
+        if temp_forecast_csv and should_precool(
             temp_forecast_csv, summer_threshold, SUMMER_PRECOOL_LOOKAHEAD
         ):
             _LOGGER.info(
-                "Activating summer precool mode due to forecasted high temperatures"
+                "Activating precool mode due to forecasted high temperatures"
             )
-            return BRAKE_FAKE_TEMP, "precool_for_summer"
+            return BRAKE_FAKE_TEMP, "precool"
 
         if outdoor_temp >= summer_threshold:
             return outdoor_temp, "summer_mode"

--- a/custom_components/pumpsteer/utils.py
+++ b/custom_components/pumpsteer/utils.py
@@ -306,12 +306,12 @@ def safe_parse_temperature_forecast(
         return None
 
 
-def should_precool_for_summer(
+def should_precool(
     temp_forecast_csv: Optional[str],
     summer_threshold: float,
     lookahead_hours: int,
 ) -> bool:
-    """Check if forecast exceeds summer threshold within given hours."""
+    """Check if forecast exceeds threshold within given hours."""
     if not temp_forecast_csv:
         return False
 

--- a/other/packages.yaml
+++ b/other/packages.yaml
@@ -177,8 +177,8 @@ template:
               🔥 Heating ({{ temp_diff | round(1) }}°C below target)
             {% elif mode == 'cooling' %}
               ❄️ Cooling ({{ temp_diff | round(1) }}°C above target)
-            {% elif mode == 'precool_for_summer' %}
-              🧊 Precooling for Summer
+            {% elif mode == 'precool' %}
+              🧊 Precooling
             {% elif mode == 'summer_mode' %}
               ☀️ Summer Mode
             {% elif mode == 'neutral' %}

--- a/tests/test_temperature_vs_price.py
+++ b/tests/test_temperature_vs_price.py
@@ -106,7 +106,7 @@ def test_precool_triggered_by_forecast():
     s = create_sensor(hass)
     data = base_sensor_data(outdoor_temp_forecast_entity="input_text.hourly_forecast_temperatures")
     fake_temp, mode = s._calculate_output_temperature(data, [], "normal", 0)
-    assert mode == "precool_for_summer"
+    assert mode == "precool"
     assert fake_temp == BRAKE_FAKE_TEMP
 
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -3,7 +3,7 @@ from custom_components.pumpsteer.utils import get_version
 
 
 def test_get_version_reads_manifest():
-    assert get_version() == "1.5.0-beta"
+    assert get_version() == "1.5.0-beta1"
 
 
 def test_get_version_missing_manifest(monkeypatch):


### PR DESCRIPTION
## Summary
- rename `precool_for_summer` mode and utility function to `precool`
- adjust logs and status template for new precool mode
- update tests to expect `precool` and correct manifest version

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b91d11e698832e9c90d4ad1e209d39