### PR TITLE
Rename precool_for_summer mode to precool

### DIFF
--- a/custom_components/pumpsteer/sensor/sensor.py
+++ b/custom_components/pumpsteer/sensor/sensor.py
@@ -299,7 +299,7 @@ class PumpSteerSensor(Entity):
             _LOGGER.info(
                 "Activating summer precool mode due to forecasted high temperatures"
             )
-            return BRAKE_FAKE_TEMP, "precool_for_summer"
+            return BRAKE_FAKE_TEMP, "precool"
 
         if outdoor_temp >= summer_threshold:
             return outdoor_temp, "summer_mode"

--- a/other/packages.yaml
+++ b/other/packages.yaml
@@ -177,7 +177,7 @@ template:
               🔥 Heating ({{ temp_diff | round(1) }}°C below target)
             {% elif mode == 'cooling' %}
               ❄️ Cooling ({{ temp_diff | round(1) }}°C above target)
-            {% elif mode == 'precool_for_summer' %}
+            {% elif mode == 'precool' %}
               🧊 Precooling for Summer
             {% elif mode == 'summer_mode' %}
               ☀️ Summer Mode

--- a/tests/test_temperature_vs_price.py
+++ b/tests/test_temperature_vs_price.py
@@ -106,7 +106,7 @@ def test_precool_triggered_by_forecast():
     s = create_sensor(hass)
     data = base_sensor_data(outdoor_temp_forecast_entity="input_text.hourly_forecast_temperatures")
     fake_temp, mode = s._calculate_output_temperature(data, [], "normal", 0)
-    assert mode == "precool_for_summer"
+    assert mode == "precool"
     assert fake_temp == BRAKE_FAKE_TEMP
 
 
@@ -116,7 +116,7 @@ def test_precool_triggered_by_long_term_forecast():
     s = create_sensor(hass)
     data = base_sensor_data(outdoor_temp_forecast_entity="input_text.hourly_forecast_temperatures")
     fake_temp, mode = s._calculate_output_temperature(data, [], "normal", 0)
-    assert mode == "precool_for_summer"
+    assert mode == "precool"
     assert fake_temp == BRAKE_FAKE_TEMP
 
 


### PR DESCRIPTION
## Summary
- Simplify summer precool mode identifier to `precool`
- Adjust tests to match new precool mode
- Update Home Assistant package template to recognize new precool mode

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b9275c3ef0832e8aa0e4cf74659fd2