### PR TITLE
Fix decision reason for very cheap heating

### DIFF
--- a/custom_components/pumpsteer/sensor/sensor.py
+++ b/custom_components/pumpsteer/sensor/sensor.py
@@ -488,8 +488,11 @@ class PumpSteerSensor(Entity):
             'preboost': 'pre-boost (cold & expensive forecast)',
             'error': 'error in calculation',
         }
-
-        decision_reason = f"{mode} - Triggered by {decision_triggers.get(mode, 'unknown')}"
+        # If heating is enabled while prices are very cheap, the trigger should reflect that
+        if mode == 'heating' and 'very_cheap' in price_category:
+            decision_reason = f"{mode} - Triggered by very cheap price"
+        else:
+            decision_reason = f"{mode} - Triggered by {decision_triggers.get(mode, 'unknown')}"
         next_3_hours_prices = safe_array_slice(prices, now_hour, 3)
 
         attributes = {

--- a/tests/test_const.py
+++ b/tests/test_const.py
@@ -41,3 +41,28 @@ def test_build_attributes_basic():
     assert attrs["mode"] == "heating"
     assert attrs["current_price"] == 1.2
     assert "aggressiveness" in attrs
+
+
+def test_decision_reason_very_cheap_heating():
+    sensor_data = {
+        'aggressiveness': 3,
+        'inertia': 2,
+        'target_temp': 21.0,
+        'indoor_temp': 21.0,
+        'outdoor_temp': 5.0,
+        'summer_threshold': 15.0,
+        'outdoor_temp_forecast_entity': True,
+    }
+    prices = [0.5, 0.6]
+    current_price = 0.5
+    price_category = "very_cheap"
+    mode = "heating"
+    holiday = False
+    categories = ["very_cheap", "cheap"]
+    now_hour = 0
+
+    s = sensor.PumpSteerSensor(DummyHass(), DummyConfigEntry())
+    s._state = 5.0
+
+    attrs = s._build_attributes(sensor_data, prices, current_price, price_category, mode, holiday, categories, now_hour)
+    assert attrs["decision_reason"] == "heating - Triggered by very cheap price"

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -3,7 +3,7 @@ from custom_components.pumpsteer.utils import get_version
 
 
 def test_get_version_reads_manifest():
-    assert get_version() == "1.5.0-beta1"
+    assert get_version() == "1.5.0"
 
 
 def test_get_version_missing_manifest(monkeypatch):


### PR DESCRIPTION
## Summary
- Show "very cheap" as heating trigger when overshoot is caused by low price
- Adjust tests for version and add coverage for new decision reason

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c1dcb6555c832e8441a31c7374c1c9