### PR TITLE
Add precool margin to forecast logic

### DIFF
--- a/custom_components/pumpsteer/sensor/sensor.py
+++ b/custom_components/pumpsteer/sensor/sensor.py
@@ -27,6 +27,7 @@ from ..settings import (
     PREBOOST_OUTPUT_TEMP,
     WINTER_BRAKE_TEMP_OFFSET,
     CHEAP_PRICE_OVERSHOOT,
+    PRECOOL_MARGIN,
 )
 from ..utils import (
     safe_float,
@@ -295,7 +296,9 @@ class PumpSteerSensor(Entity):
             _LOGGER.info(f"Pre-boost activated. Setting fake temp to {PREBOOST_OUTPUT_TEMP} °C")
             return PREBOOST_OUTPUT_TEMP, "preboost"
 
-        if temp_forecast_csv and should_precool(temp_forecast_csv, summer_threshold):
+        if temp_forecast_csv and should_precool(
+            temp_forecast_csv, summer_threshold + PRECOOL_MARGIN
+        ):
             _LOGGER.info(
                 "Activating summer precool mode due to forecasted high temperatures"
             )

--- a/custom_components/pumpsteer/settings.py
+++ b/custom_components/pumpsteer/settings.py
@@ -31,6 +31,7 @@ MIN_FAKE_TEMP: Final[float] = -25.0
 MAX_FAKE_TEMP: Final[float] = 25.0
 BRAKE_FAKE_TEMP: Final[float] = 20.0
 PRECOOL_LOOKAHEAD: Final[int] = 24  # Hours ahead to look for precooling
+PRECOOL_MARGIN: Final[float] = 1.0  # °C margin added to summer threshold for precooling
 WINTER_BRAKE_TEMP_OFFSET: Final[float] = 10.0  # °C offset above outdoor temp when braking in winter
 CHEAP_PRICE_OVERSHOOT: Final[float] = 0.0  # °C to overshoot target when prices are very cheap
 HEATING_COMPENSATION_FACTOR: Final[float] = (

--- a/custom_components/pumpsteer/utils.py
+++ b/custom_components/pumpsteer/utils.py
@@ -309,9 +309,9 @@ def safe_parse_temperature_forecast(
 
 def should_precool(
     temp_forecast_csv: Optional[str],
-    warm_threshold: float,
+    threshold_with_margin: float,
 ) -> bool:
-    """Check if forecast exceeds warm threshold within lookahead period."""
+    """Check if forecast exceeds threshold including any margin within lookahead."""
     if not temp_forecast_csv:
         return False
 
@@ -321,7 +321,7 @@ def should_precool(
     if not temps:
         return False
 
-    return any(t >= warm_threshold for t in temps)
+    return any(t >= threshold_with_margin for t in temps)
 
 
 def validate_required_entities(

--- a/tests/test_temperature_vs_price.py
+++ b/tests/test_temperature_vs_price.py
@@ -11,6 +11,7 @@ from custom_components.pumpsteer.temp_control_logic import calculate_temperature
 from custom_components.pumpsteer.settings import (
     BRAKE_FAKE_TEMP,
     HEATING_COMPENSATION_FACTOR,
+    PRECOOL_MARGIN,
 )
 import pytest
 
@@ -104,7 +105,9 @@ def test_cheap_price_neutral_behavior():
 
 
 def test_precool_triggered_by_forecast():
-    forecast = "17,19,17"
+    st = base_sensor_data()["summer_threshold"]
+    trigger = st + PRECOOL_MARGIN
+    forecast = f"{st - 1},{trigger},{st - 1}"
     hass = DummyHass({"input_text.hourly_forecast_temperatures": forecast})
     s = create_sensor(hass)
     data = base_sensor_data(outdoor_temp_forecast_entity="input_text.hourly_forecast_temperatures")
@@ -114,7 +117,9 @@ def test_precool_triggered_by_forecast():
 
 
 def test_precool_triggered_by_long_term_forecast():
-    forecast = "17,17,17,17,17,17,19"
+    st = base_sensor_data()["summer_threshold"]
+    trigger = st + PRECOOL_MARGIN
+    forecast = ",".join([str(st - 1)] * 6 + [str(trigger)])
     hass = DummyHass({"input_text.hourly_forecast_temperatures": forecast})
     s = create_sensor(hass)
     data = base_sensor_data(outdoor_temp_forecast_entity="input_text.hourly_forecast_temperatures")


### PR DESCRIPTION
## Summary
- add `PRECOOL_MARGIN` setting
- include precool margin when evaluating summer forecast
- update tests for precooling behaviour

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c3a319cb0c832e9951363adf3c61b3