### PR TITLE
Refactor electricity price utilities for slot-based calculations

### DIFF
--- a/custom_components/pumpsteer/settings.py
+++ b/custom_components/pumpsteer/settings.py
@@ -6,6 +6,10 @@ _LOGGER = logging.getLogger(__name__)
 # === VERSION INFO ===
 PUMPSTEER_VERSION: Final[str] = "1.2.1"
 
+# === TIME SLOT SETTINGS ===
+INTERVAL_MINUTES: Final[int] = 60  # Minutes per price interval
+SLOTS_PER_HOUR: Final[int] = 60 // INTERVAL_MINUTES
+
 # === HOUSE CONTROL SETTINGS ===
 DEFAULT_HOUSE_INERTIA: Final[float] = 1.0  # Default house thermal inertia
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,9 +1,14 @@
 import builtins
+import json
+from pathlib import Path
 from custom_components.pumpsteer.utils import get_version
 
 
 def test_get_version_reads_manifest():
-    assert get_version() == "1.5.0"
+    manifest_path = Path("custom_components/pumpsteer/manifest.json")
+    with open(manifest_path) as f:
+        version = json.load(f)["version"]
+    assert get_version() == version
 
 
 def test_get_version_missing_manifest(monkeypatch):


### PR DESCRIPTION
## Summary
- share INTERVAL_MINUTES and SLOTS_PER_HOUR constants via settings
- rename cheapest/expensive helpers to slot-based names
- update boost potential to work with slots and expose `boost_slots`
- adjust tests to read manifest version

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c797d29f70832ea9f035539f45f5fa