### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -1,4 +1,6 @@
 name: Run Unit Tests
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/JohanAlvedal/PumpSteer/security/code-scanning/1](https://github.com/JohanAlvedal/PumpSteer/security/code-scanning/1)

To fix the problem, you should add an explicit `permissions` block at either the workflow level (top of the file, so it applies to all jobs by default) or at the job level (under the specific job requiring the permissions). Since this workflow does not need anything beyond reading code from the repository, the most restrictive permission is `contents: read`. Applying this permission reduces the risk of unintended changes or leaks by the workflow. The best approach is to add the following block immediately after the `name:` field and before the `on:` block, so all jobs in the workflow inherit it unless overridden.

**Steps:**
- Edit .github/workflows/unit-tests.yml
- Insert the following at the top, after `name: Run Unit Tests`:
  ```yaml
  permissions:
    contents: read
  ```
- No methods, imports, or further configuration changes are needed, as this is a YAML metadata fix.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
