### PR TITLE
Remove ML attributes from main sensor

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -3,7 +3,7 @@ from custom_components.pumpsteer.utils import get_version
 
 
 def test_get_version_reads_manifest():
-    assert get_version() == "1.5.0"
+    assert get_version() == "1.5.1-beta2"
 
 
 def test_get_version_missing_manifest(monkeypatch):


### PR DESCRIPTION
## Summary
- remove all ML-related attributes from the primary PumpSteer sensor entity
- keep ML data collection while reserving ML status reporting for the ML analysis sensor
- align unit test expectation with the manifest version to keep the test suite passing

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d105e432c4832e87c6cedd5c1d2a66