### PR TITLE
Adjust expensive price braking tolerance

### DIFF
--- a/custom_components/pumpsteer/sensor/sensor.py
+++ b/custom_components/pumpsteer/sensor/sensor.py
@@ -337,6 +337,24 @@ class PumpSteerSensor(Entity):
                 _LOGGER.error(f"Error in temperature calculation: {e}")
                 fake_temp, mode = outdoor_temp, "error"
 
+            temp_deficit = target_temp_for_logic - indoor_temp
+            max_deficit = (
+                NEUTRAL_TEMP_THRESHOLD
+                * (1.0 - min(1.0, aggressiveness / 5.0))
+                + NEUTRAL_TEMP_THRESHOLD
+            )
+            if (
+                mode == "heating"
+                and (
+                    "expensive" in price_category
+                    or "very_expensive" in price_category
+                    or "extreme" in price_category
+                )
+                and temp_deficit < max_deficit
+            ):
+                # Ngenic-inspired braking tightens as aggressiveness approaches 5 to avoid wasteful heating.
+                return BRAKING_MODE_TEMP, "braking_by_price"
+
         if mode not in ["braking_by_temp", "heating"] and (
             "expensive" in price_category
             or "very_expensive" in price_category

--- a/tests/test_temperature_vs_price.py
+++ b/tests/test_temperature_vs_price.py
@@ -69,6 +69,14 @@ def test_heating_not_blocked_by_expensive_price():
     assert fake_temp < data["outdoor_temp"]
 
 
+def test_price_brake_for_small_deficit_when_expensive():
+    s = create_sensor()
+    data = base_sensor_data(indoor_temp=20.7, target_temp=21.0)
+    fake_temp, mode = s._calculate_output_temperature(data, [], "very_expensive", 0)
+    assert mode == "braking_by_price"
+    assert fake_temp == sensor.BRAKING_MODE_TEMP
+
+
 def test_price_brake_when_neutral():
     s = create_sensor()
     data = base_sensor_data()


### PR DESCRIPTION
## Summary
- introduce dynamic tolerance after temperature calculation to avoid heating during expensive prices when the deficit is small
- align braking response with Ngenic-inspired aggressiveness scaling and return braking_by_price when appropriate
- add regression test ensuring small deficits brake during expensive periods while larger deficits continue heating

## Testing
- pytest tests/test_temperature_vs_price.py

------
https://chatgpt.com/codex/tasks/task_e_68d8f108aaac832e82f2a3e815109760