### PR TITLE
Support quarter-hour electricity prices

### DIFF
--- a/tests/test_const.py
+++ b/tests/test_const.py
@@ -42,7 +42,16 @@ def test_build_attributes_basic():
     s._state = 5.0
 
     attrs = s._build_attributes(
-        sensor_data, prices, current_price, price_category, mode, holiday, categories, now_hour
+        sensor_data,
+        prices,
+        current_price,
+        price_category,
+        mode,
+        holiday,
+        categories,
+        now_hour,
+        60,
+        now_hour,
     )
     assert attrs["mode"] == "heating"
     assert attrs["current_price"] == 1.2
@@ -72,7 +81,16 @@ def test_decision_reason_very_cheap_heating():
     s._state = 5.0
 
     attrs = s._build_attributes(
-        sensor_data, prices, current_price, price_category, mode, holiday, categories, now_hour
+        sensor_data,
+        prices,
+        current_price,
+        price_category,
+        mode,
+        holiday,
+        categories,
+        now_hour,
+        60,
+        now_hour,
     )
     assert attrs["decision_reason"] == "heating - Triggered by very cheap price"
 
@@ -99,7 +117,16 @@ def test_decision_reason_precool():
     s._state = 5.0
 
     attrs = s._build_attributes(
-        sensor_data, prices, current_price, price_category, mode, holiday, categories, now_hour
+        sensor_data,
+        prices,
+        current_price,
+        price_category,
+        mode,
+        holiday,
+        categories,
+        now_hour,
+        60,
+        now_hour,
     )
     assert attrs["decision_reason"] == "precool - Triggered by pre-cool (warm forecast)"
 

--- a/tests/test_temperature_vs_price.py
+++ b/tests/test_temperature_vs_price.py
@@ -64,7 +64,7 @@ def base_sensor_data(**kwargs):
 def test_heating_not_blocked_by_expensive_price():
     s = create_sensor()
     data = base_sensor_data(indoor_temp=19.0, target_temp=21.0)
-    fake_temp, mode = s._calculate_output_temperature(data, [], "very_expensive", 0)
+    fake_temp, mode = s._calculate_output_temperature(data, [], "very_expensive", 0, 60)
     assert mode == "heating"
     assert fake_temp < data["outdoor_temp"]
 
@@ -72,7 +72,7 @@ def test_heating_not_blocked_by_expensive_price():
 def test_price_brake_for_small_deficit_when_expensive():
     s = create_sensor()
     data = base_sensor_data(indoor_temp=20.7, target_temp=21.0)
-    fake_temp, mode = s._calculate_output_temperature(data, [], "very_expensive", 0)
+    fake_temp, mode = s._calculate_output_temperature(data, [], "very_expensive", 0, 60)
     assert mode == "braking_by_price"
     assert fake_temp == sensor.BRAKING_MODE_TEMP
 
@@ -80,7 +80,7 @@ def test_price_brake_for_small_deficit_when_expensive():
 def test_price_brake_when_neutral():
     s = create_sensor()
     data = base_sensor_data()
-    fake_temp, mode = s._calculate_output_temperature(data, [], "expensive", 0)
+    fake_temp, mode = s._calculate_output_temperature(data, [], "expensive", 0, 60)
     assert mode == "braking_by_price"
     assert fake_temp == sensor.BRAKING_MODE_TEMP
 
@@ -88,7 +88,7 @@ def test_price_brake_when_neutral():
 def test_extreme_price_brake_when_neutral():
     s = create_sensor()
     data = base_sensor_data()
-    fake_temp, mode = s._calculate_output_temperature(data, [], "extreme", 0)
+    fake_temp, mode = s._calculate_output_temperature(data, [], "extreme", 0, 60)
     assert mode == "braking_by_price"
     assert fake_temp == sensor.BRAKING_MODE_TEMP
 
@@ -98,7 +98,7 @@ def test_very_cheap_price_overshoots_target():
     data = base_sensor_data()
     original_overshoot = sensor.CHEAP_PRICE_OVERSHOOT
     sensor.CHEAP_PRICE_OVERSHOOT = 0.6  # Ensure overshoot is active for the test
-    fake_temp, mode = s._calculate_output_temperature(data, [], "very_cheap", 0)
+    fake_temp, mode = s._calculate_output_temperature(data, [], "very_cheap", 0, 60)
     sensor.CHEAP_PRICE_OVERSHOOT = original_overshoot
     assert mode == "heating"
     assert fake_temp < data["outdoor_temp"]
@@ -107,7 +107,7 @@ def test_very_cheap_price_overshoots_target():
 def test_cheap_price_neutral_behavior():
     s = create_sensor()
     data = base_sensor_data()
-    fake_temp, mode = s._calculate_output_temperature(data, [], "cheap", 0)
+    fake_temp, mode = s._calculate_output_temperature(data, [], "cheap", 0, 60)
     assert mode == "neutral"
     assert fake_temp == data["outdoor_temp"]
 
@@ -119,7 +119,7 @@ def test_precool_triggered_by_forecast():
     hass = DummyHass({"input_text.hourly_forecast_temperatures": forecast})
     s = create_sensor(hass)
     data = base_sensor_data(outdoor_temp_forecast_entity="input_text.hourly_forecast_temperatures")
-    fake_temp, mode = s._calculate_output_temperature(data, [], "normal", 0)
+    fake_temp, mode = s._calculate_output_temperature(data, [], "normal", 0, 60)
     assert mode == "precool"
     assert fake_temp == BRAKE_FAKE_TEMP
 
@@ -131,7 +131,7 @@ def test_precool_triggered_by_long_term_forecast():
     hass = DummyHass({"input_text.hourly_forecast_temperatures": forecast})
     s = create_sensor(hass)
     data = base_sensor_data(outdoor_temp_forecast_entity="input_text.hourly_forecast_temperatures")
-    fake_temp, mode = s._calculate_output_temperature(data, [], "normal", 0)
+    fake_temp, mode = s._calculate_output_temperature(data, [], "normal", 0, 60)
     assert mode == "precool"
     assert fake_temp == BRAKE_FAKE_TEMP
 
@@ -160,7 +160,7 @@ def test_fake_temp_constraint_applied():
         outdoor_temp=5.0,  # Cold outdoor temp
         aggressiveness=5.0  # Maximum aggressiveness
     )
-    fake_temp, mode = s._calculate_output_temperature(data, [], "normal", 0)
+    fake_temp, mode = s._calculate_output_temperature(data, [], "normal", 0, 60)
     
     # The fake_temp should be constrained to BRAKE_FAKE_TEMP (25.0)
     assert fake_temp <= BRAKE_FAKE_TEMP
@@ -176,7 +176,7 @@ def test_price_brake_consistent_across_temperatures():
     
     for outdoor_temp in outdoor_temps:
         data = base_sensor_data(outdoor_temp=outdoor_temp)
-        fake_temp, mode = s._calculate_output_temperature(data, [], "expensive", 0)
+        fake_temp, mode = s._calculate_output_temperature(data, [], "expensive", 0, 60)
         
         assert mode == "braking_by_price", f"Mode should be braking_by_price for outdoor_temp {outdoor_temp}"
         assert fake_temp == sensor.BRAKING_MODE_TEMP, f"fake_temp should be {sensor.BRAKING_MODE_TEMP} for outdoor_temp {outdoor_temp}, got {fake_temp}"
@@ -190,7 +190,7 @@ def test_price_brake_different_categories():
     expensive_categories = ["expensive", "very_expensive", "extreme"]
     
     for category in expensive_categories:
-        fake_temp, mode = s._calculate_output_temperature(data, [], category, 0)
+        fake_temp, mode = s._calculate_output_temperature(data, [], category, 0, 60)
         
         assert mode == "braking_by_price", f"Mode should be braking_by_price for {category}"
         assert fake_temp == sensor.BRAKING_MODE_TEMP, f"fake_temp should be {sensor.BRAKING_MODE_TEMP} for {category}, got {fake_temp}"

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,5 +1,15 @@
 import builtins
-from custom_components.pumpsteer.utils import get_version
+from datetime import datetime
+
+from custom_components.pumpsteer.utils import (
+    get_version,
+    detect_price_interval_minutes,
+    compute_price_slot_index,
+    hours_to_intervals,
+    intervals_to_hours,
+    aggregate_price_series,
+    get_price_window_for_hours,
+)
 
 
 def test_get_version_reads_manifest():
@@ -11,3 +21,37 @@ def test_get_version_missing_manifest(monkeypatch):
         raise FileNotFoundError
     monkeypatch.setattr(builtins, "open", fake_open)
     assert get_version() == "unknown"
+
+
+def test_detect_price_interval_minutes_for_hourly_data():
+    prices = [float(i) for i in range(24)]
+    assert detect_price_interval_minutes(prices) == 60
+
+
+def test_detect_price_interval_minutes_for_quarter_hour_data():
+    prices = [float(i) for i in range(96)]
+    assert detect_price_interval_minutes(prices) == 15
+
+
+def test_compute_price_slot_index_for_quarter_hour_series():
+    moment = datetime(2024, 10, 1, 12, 30)
+    assert compute_price_slot_index(moment, 15, 96) == 50
+
+
+def test_hours_interval_conversions():
+    assert hours_to_intervals(3, 60) == 3
+    assert hours_to_intervals(3, 15) == 12
+    assert intervals_to_hours(12, 15) == 3.0
+
+
+def test_aggregate_price_series_to_hourly():
+    prices = [float(i) for i in range(8)]  # Two hours of quarter-hour data
+    aggregated = aggregate_price_series(prices, 15, 60)
+    assert aggregated == [1.5, 5.5]
+
+
+def test_get_price_window_for_hours_respects_duration():
+    prices = [float(i) for i in range(96)]
+    window = get_price_window_for_hours(prices, start_index=4, hours=3, interval_minutes=15)
+    assert len(window) == 12
+    assert window[0] == prices[4]


### PR DESCRIPTION
## Summary
- detect the incoming 15-minute electricity price cadence and use slot-based indexing throughout the sensor
- expose interval metadata in sensor attributes and aggregate prices for pre-boost logic
- adjust forecast/boost helpers and unit tests to handle sub-hourly prices

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d95d6850ac832ebbb26b00136a6714