### PR TITLE
Improve price braking near target temperature

### DIFF
--- a/tests/test_temperature_vs_price.py
+++ b/tests/test_temperature_vs_price.py
@@ -77,6 +77,14 @@ def test_price_brake_for_small_deficit_when_expensive():
     assert fake_temp == sensor.BRAKING_MODE_TEMP
 
 
+def test_price_brake_with_high_aggressiveness_near_target():
+    s = create_sensor()
+    data = base_sensor_data(indoor_temp=20.4, target_temp=21.0, aggressiveness=5.0)
+    fake_temp, mode = s._calculate_output_temperature(data, [], "very_expensive", 0, 60)
+    assert mode == "braking_by_price"
+    assert fake_temp == sensor.BRAKING_MODE_TEMP
+
+
 def test_price_brake_when_neutral():
     s = create_sensor()
     data = base_sensor_data()


### PR DESCRIPTION
## Summary
- adjust the price braking window to scale with aggressiveness so expensive slots stop heating sooner
- add a regression test to cover braking when prices are high and the room is close to the target temperature

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d962c1c23c832e8e9c51b9b4c46a21