### PR TITLE
Add FAQ clarifications about PumpSteer control and metrics

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -13,7 +13,7 @@ from custom_components.pumpsteer.utils import (
 
 
 def test_get_version_reads_manifest():
-    assert get_version() == "1.5.1-beta2"
+    assert get_version() == "1.6.0"
 
 
 def test_get_version_missing_manifest(monkeypatch):


### PR DESCRIPTION
## Summary
- add a FAQ section to the README clarifying how PumpSteer interacts with heat pumps, inertia learning, required sensors, and the efficiency score
- update the utils test to expect the current manifest version when validating get_version

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dacd71a454832e9a23fec3eb853f6f