### PR TITLE
Add helper utilities for price intervals

### DIFF
--- a/tests/test_const.py
+++ b/tests/test_const.py
@@ -42,7 +42,16 @@ def test_build_attributes_basic():
     s._state = 5.0
 
     attrs = s._build_attributes(
-        sensor_data, prices, current_price, price_category, mode, holiday, categories, now_hour
+        sensor_data,
+        prices,
+        current_price,
+        price_category,
+        mode,
+        holiday,
+        categories,
+        now_hour,
+        price_interval_minutes=60,
+        current_slot_index=0,
     )
     assert attrs["mode"] == "heating"
     assert attrs["current_price"] == 1.2
@@ -72,7 +81,16 @@ def test_decision_reason_very_cheap_heating():
     s._state = 5.0
 
     attrs = s._build_attributes(
-        sensor_data, prices, current_price, price_category, mode, holiday, categories, now_hour
+        sensor_data,
+        prices,
+        current_price,
+        price_category,
+        mode,
+        holiday,
+        categories,
+        now_hour,
+        price_interval_minutes=60,
+        current_slot_index=0,
     )
     assert attrs["decision_reason"] == "heating - Triggered by very cheap price"
 
@@ -99,7 +117,16 @@ def test_decision_reason_precool():
     s._state = 5.0
 
     attrs = s._build_attributes(
-        sensor_data, prices, current_price, price_category, mode, holiday, categories, now_hour
+        sensor_data,
+        prices,
+        current_price,
+        price_category,
+        mode,
+        holiday,
+        categories,
+        now_hour,
+        price_interval_minutes=60,
+        current_slot_index=0,
     )
     assert attrs["decision_reason"] == "precool - Triggered by pre-cool (warm forecast)"
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,9 +1,16 @@
 import builtins
-from custom_components.pumpsteer.utils import get_version
+from datetime import datetime
+
+from custom_components.pumpsteer.utils import (
+    compute_price_slot_index,
+    detect_price_interval_minutes,
+    get_price_window_for_hours,
+    get_version,
+)
 
 
 def test_get_version_reads_manifest():
-    assert get_version() == "1.5.1-beta2"
+    assert get_version() == "1.6.0"
 
 
 def test_get_version_missing_manifest(monkeypatch):
@@ -11,3 +18,20 @@ def test_get_version_missing_manifest(monkeypatch):
         raise FileNotFoundError
     monkeypatch.setattr(builtins, "open", fake_open)
     assert get_version() == "unknown"
+
+
+def test_detect_price_interval_minutes_hourly():
+    hourly_prices = [1.0] * 24
+    assert detect_price_interval_minutes(hourly_prices) == 60
+
+
+def test_compute_price_slot_index_clamps_to_range():
+    current_time = datetime(2023, 1, 1, 23, 59)
+    index = compute_price_slot_index(current_time, 60, 24)
+    assert index == 23
+
+
+def test_get_price_window_for_hours_returns_expected_slice():
+    prices = [float(i) for i in range(10)]
+    window = get_price_window_for_hours(prices, current_slot_index=2, hours=3, price_interval_minutes=60)
+    assert window == [2.0, 3.0, 4.0]


### PR DESCRIPTION
## Summary
- add utilities for detecting price intervals, slot indexes, and price windows
- adjust sensor attribute tests for new helper parameters and current manifest version
- cover the new helpers with unit tests

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68fa490dffac832ebd4fa8cb1bcaad1c