### PR TITLE
Use setting constants for winter brake threshold

### DIFF
--- a/custom_components/pumpsteer/sensor/sensor.py
+++ b/custom_components/pumpsteer/sensor/sensor.py
@@ -24,6 +24,7 @@ from ..settings import (
     BRAKE_FAKE_TEMP,
     AGGRESSIVENESS_SCALING_FACTOR,
     WINTER_BRAKE_TEMP_OFFSET,
+    WINTER_BRAKE_THRESHOLD,
     CHEAP_PRICE_OVERSHOOT,
     PRECOOL_MARGIN,
 )
@@ -285,7 +286,7 @@ class PumpSteerSensor(Entity):
         # Dynamic braking temperature based on outdoor temp
         brake_temp = (
             outdoor_temp + WINTER_BRAKE_TEMP_OFFSET
-            if outdoor_temp < summer_threshold
+            if outdoor_temp < WINTER_BRAKE_THRESHOLD
             else BRAKE_FAKE_TEMP
         )
 

--- a/custom_components/pumpsteer/settings.py
+++ b/custom_components/pumpsteer/settings.py
@@ -27,6 +27,7 @@ BRAKE_FAKE_TEMP: Final[float] = 25.0
 PRECOOL_LOOKAHEAD: Final[int] = 24  # Hours ahead to look for precooling
 PRECOOL_MARGIN: Final[float] = 3.0  # °C margin added to summer threshold for precooling
 WINTER_BRAKE_TEMP_OFFSET: Final[float] = 10.0  # °C offset above outdoor temp when braking in winter
+WINTER_BRAKE_THRESHOLD: Final[float] = 5.0  # °C threshold for applying winter brake offset
 CHEAP_PRICE_OVERSHOOT: Final[float] = 1.5  # °C to overshoot target when prices are very cheap
 HEATING_COMPENSATION_FACTOR: Final[float] = (
     0.2  # Factor for lowering fake temp per °C deficit and aggressiveness unit

--- a/tests/test_temperature_vs_price.py
+++ b/tests/test_temperature_vs_price.py
@@ -11,6 +11,8 @@ from custom_components.pumpsteer.temp_control_logic import calculate_temperature
 from custom_components.pumpsteer.settings import (
     BRAKE_FAKE_TEMP,
     HEATING_COMPENSATION_FACTOR,
+    WINTER_BRAKE_TEMP_OFFSET,
+    WINTER_BRAKE_THRESHOLD,
     PRECOOL_MARGIN,
 )
 import pytest
@@ -156,6 +158,38 @@ def test_fake_temp_constraint_applied():
     # The fake_temp should be constrained to BRAKE_FAKE_TEMP (25.0)
     assert fake_temp <= BRAKE_FAKE_TEMP
     assert fake_temp == BRAKE_FAKE_TEMP  # Should be exactly BRAKE_FAKE_TEMP due to constraint
+
+
+def test_brake_temp_uses_offset_below_five_degrees():
+    """Ensure braking only adds offset to outdoor temp when it's below 5 °C."""
+    s = create_sensor()
+    data = base_sensor_data(
+        indoor_temp=23.0,
+        target_temp=21.0,
+        outdoor_temp=WINTER_BRAKE_THRESHOLD - 1.0,
+        aggressiveness=1.0,
+    )
+
+    fake_temp, mode = s._calculate_output_temperature(data, [], "normal", 0)
+
+    assert mode == "braking_by_temp"
+    assert fake_temp == data["outdoor_temp"] + WINTER_BRAKE_TEMP_OFFSET
+
+
+def test_brake_temp_caps_to_brake_fake_temp_above_five_degrees():
+    """Ensure braking uses the global cap when outdoor temp is 5 °C or warmer."""
+    s = create_sensor()
+    data = base_sensor_data(
+        indoor_temp=23.0,
+        target_temp=21.0,
+        outdoor_temp=WINTER_BRAKE_THRESHOLD + 1.0,
+        aggressiveness=1.0,
+    )
+
+    fake_temp, mode = s._calculate_output_temperature(data, [], "normal", 0)
+
+    assert mode == "braking_by_temp"
+    assert fake_temp == BRAKE_FAKE_TEMP
 
 
 def test_price_brake_consistent_across_temperatures():


### PR DESCRIPTION
## Summary
- add a dedicated winter brake temperature threshold constant to settings
- update brake temperature calculation to use settings constant instead of inline value
- align brake temperature tests with the shared constants for offset and threshold

## Testing
- pytest

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692448a85120832eb01bead85201acbf)