### PR TITLE
Scale braking cap for aggressiveness 1–3 while keeping hard cap for 4–5

### DIFF
--- a/custom_components/pumpsteer/temp_control_logic.py
+++ b/custom_components/pumpsteer/temp_control_logic.py
@@ -90,7 +90,12 @@ def calculate_temperature_output(
     elif diff > 0.5:
         fake_temp += diff * aggressiveness * BRAKING_COMPENSATION_FACTOR
         brake_cap = max(min(brake_temp, MAX_FAKE_TEMP), MIN_FAKE_TEMP)
-        fake_temp = brake_cap
+        if aggressiveness >= 4:
+            fake_temp = brake_cap
+        else:
+            ramp_ratio = aggressiveness / 3
+            dynamic_cap = real_outdoor_temp + (brake_cap - real_outdoor_temp) * ramp_ratio
+            fake_temp = min(fake_temp, dynamic_cap)
         mode = "braking_by_temp"
         _LOGGER.debug(
             "TempControl: Braking (fake temp: %.1f °C, diff: %.2f, agg: %.1f) - Mode: %s",


### PR DESCRIPTION
### Motivation
- Introduce progressive, dynamic braking for medium aggressiveness levels so braking scales with `aggressiveness` instead of immediately applying a hard cap.
- Preserve a strict hard cap for high aggressiveness (`4`–`5`) to ensure strong braking when explicitly requested. 
- Align behavior with the intent that aggressiveness 0 should be a bypass, and 1–3 should apply increasing (but dynamic) braking. 

### Description
- Modified `calculate_temperature_output` in `custom_components/pumpsteer/temp_control_logic.py` to keep the hard `brake_cap` when `aggressiveness >= 4`, and otherwise compute a `ramp_ratio = aggressiveness / 3` and `dynamic_cap = real_outdoor_temp + (brake_cap - real_outdoor_temp) * ramp_ratio` and clamp `fake_temp` to `min(fake_temp, dynamic_cap)`.
- Updated `tests/test_temperature_vs_price.py` to use `aggressiveness=4` for existing brake-cap checks and added `test_brake_temp_dynamic_at_medium_aggressiveness` and `test_brake_temp_scales_with_aggressiveness_levels` to validate dynamic scaling for aggressiveness 1–3.
- Retained existing safety clamps (`MIN_FAKE_TEMP`, `MAX_FAKE_TEMP`) and debug/warning logging in the code.

### Testing
- Ran `pytest -q` after the changes and the run failed during collection with `ModuleNotFoundError: No module named 'homeassistant'`.
- Re-ran `pytest -q` and observed the same `ModuleNotFoundError`, so no unit tests executed to completion.
- Tests added/modified: `tests/test_temperature_vs_price.py` (new dynamic and progressive braking checks) and existing tests were adjusted to use `aggressiveness=4` where appropriate.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6952e5097f64832e8de15fe1981d8097)