### PR TITLE
Add optional supply temperature sensor and optional-entity validation

### DIFF
--- a/custom_components/pumpsteer/options_flow.py
+++ b/custom_components/pumpsteer/options_flow.py
@@ -63,6 +63,16 @@ class PumpSteerOptionsFlowHandler(config_entries.OptionsFlow):
                         "electricity_price_entity",
                         default=current_data.get("electricity_price_entity"),
                     ): selector({"entity": {"domain": "sensor"}}),
+                    vol.Optional(
+                        "supply_temp_entity",
+                        default=current_data.get("supply_temp_entity"),
+                    ): selector(
+                        {"entity": {"domain": "sensor", "device_class": "temperature"}}
+                    ),
+                    vol.Optional(
+                        "monitor_only",
+                        default=current_data.get("monitor_only", False),
+                    ): selector({"boolean": {}}),
                 }
             ),
             errors=errors,
@@ -76,6 +86,9 @@ class PumpSteerOptionsFlowHandler(config_entries.OptionsFlow):
             "indoor_temp_entity": "Indoor temperature sensor",
             "real_outdoor_entity": "Outdoor temperature sensor",
             "electricity_price_entity": "Electricity price sensor",
+        }
+        optional_entities = {
+            "supply_temp_entity": "Supply temperature sensor",
         }
 
         hardcoded_entities = {
@@ -98,6 +111,15 @@ class PumpSteerOptionsFlowHandler(config_entries.OptionsFlow):
                 errors[field] = f"Entity not found: {entity_id}"
             elif not await self._entity_available(entity_id):
                 errors[field] = f"Entity unavailable: {entity_id}"
+
+        for field in optional_entities:
+            entity_id = user_input.get(field)
+            if not entity_id:
+                continue
+            if not await self._entity_exists(entity_id):
+                _LOGGER.warning("Optional entity not found: %s", entity_id)
+            elif not await self._entity_available(entity_id):
+                _LOGGER.warning("Optional entity unavailable: %s", entity_id)
 
         for field, description in hardcoded_entities.items():
             entity_id = user_input.get(field)

--- a/custom_components/pumpsteer/strings.json
+++ b/custom_components/pumpsteer/strings.json
@@ -6,7 +6,9 @@
         "data": {
           "indoor_temp_entity": "config.step.user.data.indoor_temp_entity",
           "real_outdoor_entity": "config.step.user.data.real_outdoor_entity",
-          "electricity_price_entity": "config.step.user.data.electricity_price_entity"
+          "electricity_price_entity": "config.step.user.data.electricity_price_entity",
+          "supply_temp_entity": "config.step.user.data.supply_temp_entity",
+          "monitor_only": "config.step.user.data.monitor_only"
         }
       }
     },
@@ -23,7 +25,9 @@
         "data": {
           "indoor_temp_entity": "options.step.init.data.indoor_temp_entity",
           "real_outdoor_entity": "options.step.init.data.real_outdoor_entity",
-          "electricity_price_entity": "options.step.init.data.electricity_price_entity"
+          "electricity_price_entity": "options.step.init.data.electricity_price_entity",
+          "supply_temp_entity": "options.step.init.data.supply_temp_entity",
+          "monitor_only": "options.step.init.data.monitor_only"
         }
       }
     },

--- a/custom_components/pumpsteer/translations/en.json
+++ b/custom_components/pumpsteer/translations/en.json
@@ -6,7 +6,9 @@
         "data": {
           "indoor_temp_entity": "Indoor temperature sensor",
           "real_outdoor_entity": "Outdoor temperature sensor",
-          "electricity_price_entity": "Electricity price sensor"
+          "electricity_price_entity": "Electricity price sensor",
+          "supply_temp_entity": "Supply temperature sensor (optional)",
+          "monitor_only": "Monitor only (no control)"
         }
       }
     },
@@ -23,7 +25,9 @@
         "data": {
           "indoor_temp_entity": "Indoor temperature sensor",
           "real_outdoor_entity": "Outdoor temperature sensor",
-          "electricity_price_entity": "Electricity price sensor"
+          "electricity_price_entity": "Electricity price sensor",
+          "supply_temp_entity": "Supply temperature sensor (optional)",
+          "monitor_only": "Monitor only (no control)"
         }
       }
     },


### PR DESCRIPTION
### Motivation
- Allow providing an optional supply (flow) temperature sensor so the integration can use that data when available to improve decisions and ML training.
- Treat the supply temperature as optional so missing or unavailable sensors do not block setup or options changes.
- Surface the supply temperature in sensor attributes and ML payloads for visibility and debugging.
- Keep existing `monitor_only` behavior intact to allow running the integration in read-only/monitor mode.

### Description
- Added `supply_temp_entity` as an optional selector to the config flow and options flow (`config_flow.py`, `options_flow.py`).
- Implemented optional-entity checks that log warnings when the optional `supply_temp_entity` is missing or unavailable but do not block the flow (`_validate_entities` / optional checks).
- Read the supply temperature in `sensor._get_sensor_data` and added `supply_temp` / `supply_temp_entity` to the sensor data, included `supply_temp` in ML data in `_collect_ml_data`, and exposed `supply_temperature` and `supply_temp_available` in the sensor attributes (`sensor/sensor.py`).
- Added translation and strings keys for the new optional field in `strings.json` and `translations/en.json`.

### Testing
- Ran `pytest` repeatedly, but test collection failed with `ModuleNotFoundError: No module named 'homeassistant'`, so no unit tests executed successfully in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695418108dc0832eacb3b627748f93dc)