### PR TITLE
Fix missing indoor/outdoor reads and wire price-baseline + braking refinements

### DIFF
--- a/custom_components/pumpsteer/options_flow.py
+++ b/custom_components/pumpsteer/options_flow.py
@@ -11,6 +11,7 @@ from .settings import (
     MPC_PRICE_WEIGHT,
     MPC_COMFORT_WEIGHT,
     MPC_SMOOTH_WEIGHT,
+    DEFAULT_TRAILING_HOURS,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -111,6 +112,12 @@ class PumpSteerOptionsFlowHandler(config_entries.OptionsFlow):
                         "monitor_only",
                         default=current_data.get("monitor_only", False),
                     ): selector({"boolean": {}}),
+                    vol.Optional(
+                        "price_baseline_window_hours",
+                        default=current_data.get(
+                            "price_baseline_window_hours", DEFAULT_TRAILING_HOURS
+                        ),
+                    ): selector({"number": {"min": 24, "max": 96, "step": 24}}),
                 }
             ),
             errors=errors,

--- a/custom_components/pumpsteer/strings.json
+++ b/custom_components/pumpsteer/strings.json
@@ -27,7 +27,8 @@
           "real_outdoor_entity": "options.step.init.data.real_outdoor_entity",
           "electricity_price_entity": "options.step.init.data.electricity_price_entity",
           "supply_temp_entity": "options.step.init.data.supply_temp_entity",
-          "monitor_only": "options.step.init.data.monitor_only"
+          "monitor_only": "options.step.init.data.monitor_only",
+          "price_baseline_window_hours": "options.step.init.data.price_baseline_window_hours"
         }
       }
     },

--- a/custom_components/pumpsteer/translations/en.json
+++ b/custom_components/pumpsteer/translations/en.json
@@ -27,7 +27,8 @@
           "real_outdoor_entity": "Outdoor temperature sensor",
           "electricity_price_entity": "Electricity price sensor",
           "supply_temp_entity": "Supply temperature sensor (optional)",
-          "monitor_only": "Monitor only (no control)"
+          "monitor_only": "Monitor only (no control)",
+          "price_baseline_window_hours": "Price baseline window (hours)"
         }
       }
     },


### PR DESCRIPTION
### Motivation
- Prevent a `NameError` during entity update by ensuring indoor and outdoor temperature values are read before building `sensor_data`.
- Keep price-driven braking effective for flat-price periods by clamping and preserving braking semantics when the price range is zero.
- Make the trailing baseline window configurable and visible so local market/retention policies can be represented via `price_baseline_window_hours`.

### Description
- Restore `indoor_temp` and `outdoor_temp` reads in `_get_sensor_data` using `safe_float(get_state(...))` to fix the missing variables error.
- Keep braking effective on flat-price tariffs by clamping the computed `price_factor` to `1.0` when `price_is_high` and the computed `price_range` is zero, and blend a `price_brake_temp` between `outdoor_temp` and `brake_temp` using the adjusted `price_factor`.
- Add an options selector `price_baseline_window_hours`, thread it through the sensor config and attributes, and pass it as `trailing_hours` to `async_hybrid_classify_with_history` instead of the hardcoded `72` hours.
- Expose `price_baseline_window_hours` in the sensor attributes and update UI strings/translations for the new option.

### Testing
- Ran `pytest`; test collection failed with `ModuleNotFoundError: No module named 'homeassistant'`, so automated tests could not be executed in this environment.
- Re-ran `pytest` after the fix and observed the same `ModuleNotFoundError` during collection preventing test execution.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695ad3ca74d8832eb10751e2c2eeee78)