### PR TITLE
Add heating PI compensation inputs

### DIFF
--- a/tests/test_temperature_vs_price.py
+++ b/tests/test_temperature_vs_price.py
@@ -54,6 +54,8 @@ def base_sensor_data(**kwargs):
         "outdoor_temp": 5.0,
         "summer_threshold": 18.0,
         "aggressiveness": 3.0,
+        "integral_error": 0.0,
+        "integral_gain": 0.0,
         "inertia": 1.0,
         "outdoor_temp_forecast_entity": None,
     }
@@ -138,9 +140,11 @@ def test_heating_compensation_factor_applied():
         actual_target_temp_for_logic=21.0,
         real_outdoor_temp=5.0,
         aggressiveness=3.0,
+        integral_error=0.0,
+        integral_gain=0.0,
         brake_temp=BRAKE_FAKE_TEMP,
     )
-    expected = 5.0 + (19.0 - 21.0) * 3.0 * HEATING_COMPENSATION_FACTOR
+    expected = 5.0 + (19.0 - 21.0) * HEATING_COMPENSATION_FACTOR
     assert mode == "heating"
     assert round(fake_temp, 6) == round(expected, 6)
 


### PR DESCRIPTION
### Motivation
- Enable PI-style compensation during heating by exposing integral error and gain from Home Assistant entities.
- Ensure explicit handling of `aggressiveness = 0` so passthrough behavior is preserved.
- Reduce redundant entity reads by capturing related control inputs once in `_get_sensor_data`.

### Description
- Added `integral_error_entity` and `integral_gain_entity` to `HARDCODED_ENTITIES` and read them once in `_get_sensor_data`.
- Kept `aggressiveness` fallback as an explicit `is not None` check so a numeric 0 is respected, and defaulted integral values to `0.0`.
- Extended `calculate_temperature_output` signature to accept `integral_error` and `integral_gain` and applied a PI-style adjustment in heating mode.
- Updated tests in `tests/test_temperature_vs_price.py` to include the new parameters and adjusted the expected heating calculation.

### Testing
- Ran `pytest tests/test_temperature_vs_price.py` after changes, but test collection failed with `ModuleNotFoundError: No module named 'custom_components'` so automated tests did not complete.
- Updated unit test inputs to include `integral_error` and `integral_gain` and adjusted expected values, but full test execution could not be validated due to the import error.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695bb51ef640832eab02b2213bc96612)