### PR TITLE
Adjust braking behavior near target temperatures

### DIFF
--- a/custom_components/pumpsteer/sensor/sensor.py
+++ b/custom_components/pumpsteer/sensor/sensor.py
@@ -302,7 +302,7 @@ class PumpSteerSensor(Entity):
             or "extreme" in price_category
         )
 
-        if abs(temp_diff) <= NEUTRAL_TEMP_THRESHOLD:
+        if temp_diff < 0 and abs(temp_diff) <= NEUTRAL_TEMP_THRESHOLD:
             fake_temp = outdoor_temp
             mode = "neutral"
         else:

--- a/custom_components/pumpsteer/temp_control_logic.py
+++ b/custom_components/pumpsteer/temp_control_logic.py
@@ -93,19 +93,20 @@ def calculate_temperature_output(
             mode,
         )
 
-    # BRAKING mode (too warm indoors)
-    # If indoor temperature is significantly above target, activate braking.
-    # The fake temperature is increased to make the heat pump work less (or cool).
-    elif diff > 0.5:
+    # BRAKING mode (at or above target)
+    # If indoor temperature is at or above target, activate braking.
+    # The fake temperature is increased gradually to make the heat pump work less (or cool).
+    elif diff >= 0:
         fake_temp += diff * aggressiveness * BRAKING_COMPENSATION_FACTOR
         brake_cap = max(min(brake_temp, MAX_FAKE_TEMP), MIN_FAKE_TEMP)
-        fake_temp = brake_cap
+        fake_temp = max(min(fake_temp, brake_cap), MIN_FAKE_TEMP)
         mode = "braking_by_temp"
         _LOGGER.debug(
-            "TempControl: Braking (fake temp: %.1f °C, diff: %.2f, agg: %.1f) - Mode: %s",
+            "TempControl: Braking (fake temp: %.1f °C, diff: %.2f, agg: %.1f, cap: %.1f) - Mode: %s",
             fake_temp,
             diff,
             aggressiveness,
+            brake_cap,
             mode,
         )
 


### PR DESCRIPTION
### Motivation
- Allow braking logic to engage when indoor temperature is at or above the target rather than only when significantly above it.
- Make braking ramp toward the dynamic brake cap instead of snapping directly to the cap for smoother control.
- Avoid treating small positive deviations as neutral to ensure price- and temperature-based braking can act when appropriate.

### Description
- Updated `calculate_temperature_output` in `custom_components/pumpsteer/temp_control_logic.py` to use `elif diff >= 0` and to compute and clamp `fake_temp` toward the `brake_cap` instead of assigning the cap directly.
- Tightened the neutral-zone check in `_calculate_output_temperature` inside `custom_components/pumpsteer/sensor/sensor.py` to only treat slight negative `temp_diff` as neutral (`temp_diff < 0 and abs(temp_diff) <= NEUTRAL_TEMP_THRESHOLD`).
- Adjusted debug logging to include the computed `brake_cap` and reflect the new braking behavior.
- Changes aim to make braking behavior more gradual and to enable braking when the indoor temperature is at or above the target.

### Testing
- Ran `pytest` to validate the codebase.
- Test collection failed with `ModuleNotFoundError: No module named 'homeassistant'`, so automated tests could not be executed successfully in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695e6b4bd010832eb22877748ca3f610)