### PR TITLE
Align ML session payload with collector schema

### DIFF
--- a/custom_components/pumpsteer/manifest.json
+++ b/custom_components/pumpsteer/manifest.json
@@ -8,6 +8,6 @@
   "integration_type": "service",
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/JohanAlvedal/pumpsteer/issues",
-  "requirements": [],
+  "requirements": ["numpy"],
   "version": "1.6.5"
 }

--- a/custom_components/pumpsteer/sensor/sensor.py
+++ b/custom_components/pumpsteer/sensor/sensor.py
@@ -333,7 +333,11 @@ class PumpSteerSensor(Entity):
         return fake_temp, mode
 
     def _collect_ml_data(
-        self, sensor_data: Dict[str, Any], mode: str, fake_temp: float
+        self,
+        sensor_data: Dict[str, Any],
+        mode: str,
+        fake_temp: float,
+        current_price: float,
     ) -> None:
         """Collect data for machine learning"""
         if not self.ml_collector:
@@ -345,8 +349,10 @@ class PumpSteerSensor(Entity):
             "target_temp": sensor_data.get("target_temp"),
             "aggressiveness": sensor_data.get("aggressiveness", 0),
             "inertia": sensor_data.get("inertia"),
+            "house_inertia": sensor_data.get("inertia"),
             "mode": mode,
-            "fake_temp": fake_temp,
+            "fake_outdoor_temp": fake_temp,
+            "price_now": current_price,
             "price_category": self._last_price_category,
             "timestamp": dt_util.now().isoformat(),
         }
@@ -581,7 +587,7 @@ class PumpSteerSensor(Entity):
         )
 
         if self.ml_collector:
-            self._collect_ml_data(sensor_data, mode, fake_temp)
+            self._collect_ml_data(sensor_data, mode, fake_temp, current_price)
 
         self._last_update_time = update_time
 


### PR DESCRIPTION
### Motivation
- Säkerställa att ML-collectorn får fältnamn och värden som matchar dess förväntade schema för att undvika datamismatch.
- Ta med aktuell elprisinformation i ML-data genom att lägga till `price_now` så att modellerna kan ta hänsyn till priset vid beslut.
- Byta namn på det simulerade temperaturfältet till `fake_outdoor_temp` för att göra avsikten tydligare.
- Behålla och exponera `inertia` även som `house_inertia` för bakåtkompatibilitet med insamlingsschema.

### Description
- Ändrat signaturen för `_collect_ml_data` så att den tar `current_price` som argument och uppdaterat anropet på uppdateringsstället för att skicka `current_price`.
- Uppdaterat payload-nycklar i `ml_data` för att inkludera `fake_outdoor_temp`, `price_now` och duplicera `inertia` som `house_inertia`.
- Anpassat flödet för att starta, uppdatera och avsluta ML-sessioner utan ändrade beteenden bortsett från det nya payloadinnehållet.
- Lagt till `numpy` i `manifest.json` via `"requirements": ["numpy"]` för att deklarera ML-relaterade beroenden.

### Testing
- Körde `pytest` för att köra automatiserade tester, men testinsamling avbröts med ett fel under import.
- Testsvaret visade ett `ModuleNotFoundError: No module named 'homeassistant'` under testinsamling, vilket förhindrade att testerna kördes.
- Inga ytterligare automatiserade tester kördes efter ändringen på grund av den saknade beroenden.
- Alla ändringar kompilerades och commit:ade lokalt utan syntaktiska fel.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695ea19e6724832e91868aa770bc5bfd)