### PR TITLE
Centralisera hårdkodade entiteter och förbättra pris- och ML-datahantering

### DIFF
--- a/custom_components/pumpsteer/config_flow.py
+++ b/custom_components/pumpsteer/config_flow.py
@@ -6,22 +6,10 @@ from homeassistant.core import callback
 from homeassistant.helpers.selector import selector
 from homeassistant.const import STATE_UNAVAILABLE, STATE_UNKNOWN
 
+from .const import DOMAIN, HARDCODED_ENTITIES
 from .options_flow import PumpSteerOptionsFlowHandler
 
 _LOGGER = logging.getLogger(__name__)
-
-DOMAIN = "pumpsteer"
-
-# Hardcoded entities that are always present in the package file
-HARDCODED_ENTITIES = {
-    "target_temp_entity": "input_number.indoor_target_temperature",
-    "summer_threshold_entity": "input_number.pumpsteer_summer_threshold",
-    "holiday_mode_boolean_entity": "input_boolean.holiday_mode",
-    "holiday_start_datetime_entity": "input_datetime.holiday_start",
-    "holiday_end_datetime_entity": "input_datetime.holiday_end",
-    "auto_tune_inertia_entity": "input_boolean.autotune_inertia",
-    "hourly_forecast_temperatures_entity": "input_text.hourly_forecast_temperatures",
-}
 
 
 class PumpSteerConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
@@ -79,6 +67,9 @@ class PumpSteerConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             "holiday_start_datetime_entity": "Holiday start datetime",
             "holiday_end_datetime_entity": "Holiday end datetime",
             "auto_tune_inertia_entity": "Autotune inertia boolean",
+            "aggressiveness_entity": "Aggressiveness input_number",
+            "house_inertia_entity": "House inertia input_number",
+            "price_model_entity": "Price model input_select",
         }
 
         # Check user-selected entities (block if missing)
@@ -130,7 +121,7 @@ class PumpSteerConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
     def is_matching(self, other_flow: vol.Self) -> bool:
         """Return True if other_flow is matching this flow"""
-        raise NotImplementedError
+        return False
 
     @staticmethod
     @callback

--- a/custom_components/pumpsteer/const.py
+++ b/custom_components/pumpsteer/const.py
@@ -1,1 +1,15 @@
 DOMAIN = "pumpsteer"
+
+# Hardcoded entities that are always present in the package file.
+HARDCODED_ENTITIES = {
+    "target_temp_entity": "input_number.indoor_target_temperature",
+    "summer_threshold_entity": "input_number.pumpsteer_summer_threshold",
+    "holiday_mode_boolean_entity": "input_boolean.holiday_mode",
+    "holiday_start_datetime_entity": "input_datetime.holiday_start",
+    "holiday_end_datetime_entity": "input_datetime.holiday_end",
+    "auto_tune_inertia_entity": "input_boolean.autotune_inertia",
+    "hourly_forecast_temperatures_entity": "input_text.hourly_forecast_temperatures",
+    "aggressiveness_entity": "input_number.pumpsteer_aggressiveness",
+    "house_inertia_entity": "input_number.house_inertia",
+    "price_model_entity": "input_select.pumpsteer_price_model",
+}

--- a/custom_components/pumpsteer/manifest.json
+++ b/custom_components/pumpsteer/manifest.json
@@ -8,6 +8,6 @@
   "integration_type": "service",
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/JohanAlvedal/pumpsteer/issues",
-  "requirements": [],
+  "requirements": ["numpy"],
   "version": "1.6.5"
 }

--- a/custom_components/pumpsteer/options_flow.py
+++ b/custom_components/pumpsteer/options_flow.py
@@ -5,19 +5,9 @@ from homeassistant import config_entries
 from homeassistant.helpers.selector import selector
 from homeassistant.const import STATE_UNAVAILABLE, STATE_UNKNOWN
 
+from .const import DOMAIN, HARDCODED_ENTITIES
+
 _LOGGER = logging.getLogger(__name__)
-
-DOMAIN = "pumpsteer"
-
-HARDCODED_ENTITIES = {
-    "target_temp_entity": "input_number.indoor_target_temperature",
-    "summer_threshold_entity": "input_number.pumpsteer_summer_threshold",
-    "holiday_mode_boolean_entity": "input_boolean.holiday_mode",
-    "holiday_start_datetime_entity": "input_datetime.holiday_start",
-    "holiday_end_datetime_entity": "input_datetime.holiday_end",
-    "auto_tune_inertia_entity": "input_boolean.autotune_inertia",
-    "hourly_forecast_temperatures_entity": "input_text.hourly_forecast_temperatures",
-}
 
 
 class PumpSteerOptionsFlowHandler(config_entries.OptionsFlow):
@@ -86,6 +76,9 @@ class PumpSteerOptionsFlowHandler(config_entries.OptionsFlow):
             "holiday_start_datetime_entity": "Holiday start datetime",
             "holiday_end_datetime_entity": "Holiday end datetime",
             "auto_tune_inertia_entity": "Autotune inertia boolean",
+            "aggressiveness_entity": "Aggressiveness input_number",
+            "house_inertia_entity": "House inertia input_number",
+            "price_model_entity": "Price model input_select",
         }
 
         for field, description in user_configurable_entities.items():

--- a/custom_components/pumpsteer/sensor/ml_sensor.py
+++ b/custom_components/pumpsteer/sensor/ml_sensor.py
@@ -129,7 +129,8 @@ class PumpSteerMLSensor(Entity):
     def _determine_state(self, insights: Dict[str, Any]) -> str:
         """Decide what the main state string should be"""
         summary = insights.get("summary", {}) or {}
-        total = summary.get("total_sessions", 0) or 0
+        summary_data = summary.get("summary", {}) or {}
+        total = summary_data.get("total_sessions", 0) or 0
         coeffs = summary.get("coefficients")
 
         # Too few sessions collected → still collecting data
@@ -148,17 +149,18 @@ class PumpSteerMLSensor(Entity):
     ) -> Dict[str, Any]:
         """Build a clear and concise attribute dictionary"""
         summary = insights.get("summary", {})
+        summary_data = summary.get("summary", {})
         recs = insights.get("recommendations", [])
 
         attributes = {
-            "total_sessions": summary.get("total_sessions"),
-            "avg_duration": summary.get("avg_duration"),
-            "avg_drift": summary.get("avg_drift"),
-            "avg_inertia": summary.get("avg_inertia"),
-            "avg_aggressiveness": summary.get("avg_aggressiveness"),
+            "total_sessions": summary_data.get("total_sessions"),
+            "avg_duration": summary_data.get("avg_duration"),
+            "avg_drift": summary_data.get("avg_drift"),
+            "avg_inertia": summary_data.get("avg_inertia"),
+            "avg_aggressiveness": summary_data.get("avg_aggressiveness"),
             "coefficients": summary.get("coefficients"),
             "recommendations": recs or ["Collecting data…"],
-            "last_learning_update": summary.get("updated"),
+            "last_learning_update": summary_data.get("updated"),
             # control system info
             "auto_tune_active": control_data.get("autotune_active"),
             "inertia": control_data.get("inertia"),


### PR DESCRIPTION
### Motivation
- Centralisera och återanvända hårdkodade entitets-ID för att undvika duplicering och göra validering konsekvent i `config_flow` och `options_flow`.
- Göra pris- och prognoslogik mer robust genom att återanvända prognos-CSV och hantera olika format på prisdata.
- Förbättra ML-sensorns hantering av returstruktur och insamlade fält för att ge mer relevanta ML-payloads.
- Säkerställa att beroenden deklareras för ML-funktionalitet (`numpy`).

### Description
- Flyttat och exponerat `HARDCODED_ENTITIES` och `DOMAIN` i `custom_components/pumpsteer/const.py` och uppdaterat `config_flow.py` och `options_flow.py` att importera och använda dessa värden.
- Utökad varningsvalidering i `config_flow` och `options_flow` så att `aggressiveness_entity`, `house_inertia_entity` och `price_model_entity` kontrolleras (varning om saknas/otillgängliga).
- Uppdaterat ML-sensor i `custom_components/pumpsteer/sensor/ml_sensor.py` för att läsa den nästlade `summary["summary"]`-strukturen och använda dessa fält för status och attribut.
- Förbättrat sensorn i `custom_components/pumpsteer/sensor/sensor.py` genom att återanvända prognos-`CSV` (`outdoor_temp_forecast_csv`), byta hur `forecast_available` beräknas, göra `_get_price_data` tolerant mot dict-poster i prislistor (läser `value` eller `price`) och utöka `_collect_ml_data` signatur/payload med `house_inertia`, `price_now` och `fake_outdoor_temp`.
- Lagt till `numpy` i `manifest.json` krav för ML-stödet.

### Testing
- Körde `pytest`, testinsamling avbröts med importfel: `ModuleNotFoundError: No module named 'homeassistant'`.
- Fel uppstod i importfasen för `tests/test_const.py`, `tests/test_temperature_vs_price.py` och `tests/test_utils.py`, så inga tester kördes till slut (0 passed, 3 errors during collection).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695ea19e6724832e91868aa770bc5bfd)