### PR TITLE
Smooth fake temperature changes with ramping

### DIFF
--- a/custom_components/pumpsteer/sensor/sensor.py
+++ b/custom_components/pumpsteer/sensor/sensor.py
@@ -1,4 +1,5 @@
 import logging
+import math
 from datetime import datetime
 from typing import Optional, Dict, Any, Tuple, List
 
@@ -19,6 +20,10 @@ from ..settings import (
     HOLIDAY_TEMP,
     BRAKE_FAKE_TEMP,
     AGGRESSIVENESS_SCALING_FACTOR,
+    BRAKE_RAMP_MULTIPLIER,
+    RAMP_MAX_STEP,
+    RAMP_STEP_BASE,
+    RAMP_STEP_PER_AGGRESSIVENESS,
     WINTER_BRAKE_TEMP_OFFSET,
     WINTER_BRAKE_THRESHOLD,
     CHEAP_PRICE_OVERSHOOT,
@@ -107,6 +112,7 @@ class PumpSteerSensor(Entity):
         self._attributes = {}
         self._name = "PumpSteer"
         self._last_update_time = None
+        self._last_fake_temp = None
 
         self._attr_unit_of_measurement = "°C"
         self._attr_device_class = "temperature"
@@ -332,6 +338,30 @@ class PumpSteerSensor(Entity):
         fake_temp = min(fake_temp, BRAKE_FAKE_TEMP)
         return fake_temp, mode
 
+    def _apply_temperature_ramp(
+        self,
+        target_fake_temp: float,
+        aggressiveness: float,
+        mode: str,
+    ) -> float:
+        """Smooth temperature changes by limiting the step per update."""
+        if self._last_fake_temp is None:
+            self._last_fake_temp = target_fake_temp
+            return target_fake_temp
+
+        ramp_step = RAMP_STEP_BASE + (aggressiveness * RAMP_STEP_PER_AGGRESSIVENESS)
+        ramp_step = min(ramp_step, RAMP_MAX_STEP)
+
+        if mode in {"braking_by_price", "braking_by_temp", "precool"}:
+            ramp_step *= BRAKE_RAMP_MULTIPLIER
+
+        delta = target_fake_temp - self._last_fake_temp
+        if abs(delta) > ramp_step:
+            target_fake_temp = self._last_fake_temp + math.copysign(ramp_step, delta)
+
+        self._last_fake_temp = target_fake_temp
+        return target_fake_temp
+
     def _collect_ml_data(
         self, sensor_data: Dict[str, Any], mode: str, fake_temp: float
     ) -> None:
@@ -543,6 +573,7 @@ class PumpSteerSensor(Entity):
         missing = self._validate_required_data(sensor_data, prices)
         if missing:
             self._state = STATE_UNAVAILABLE
+            self._last_fake_temp = None
             self._attributes = {
                 "Status": f"Missing: {', '.join(missing)}",
                 "Last Updated": update_time.isoformat(),
@@ -564,6 +595,11 @@ class PumpSteerSensor(Entity):
             sensor_data,
             price_category,
             current_slot_index,
+        )
+        fake_temp = self._apply_temperature_ramp(
+            fake_temp,
+            sensor_data["aggressiveness"],
+            mode,
         )
         self._state = round(fake_temp, 1)
 

--- a/custom_components/pumpsteer/settings.py
+++ b/custom_components/pumpsteer/settings.py
@@ -30,6 +30,14 @@ HEATING_COMPENSATION_FACTOR: Final[float] = (
 BRAKING_COMPENSATION_FACTOR: Final[float] = (
     0.4  # Factor for raising fake temp per °C surplus and aggressiveness unit
 )
+RAMP_STEP_BASE: Final[float] = 0.5  # Minimum °C step per update for fake temp
+RAMP_STEP_PER_AGGRESSIVENESS: Final[float] = (
+    0.3  # Additional °C step per aggressiveness unit
+)
+RAMP_MAX_STEP: Final[float] = 3.0  # Hard cap on °C step per update
+BRAKE_RAMP_MULTIPLIER: Final[float] = (
+    1.25  # Allow slightly faster ramp when braking modes are active
+)
 
 # === COMFORT CONTROL SETTINGS ===
 # Defines when the system considers the indoor temperature "too cold"


### PR DESCRIPTION
### Motivation
- Reduce abrupt jumps in the computed fake/outdoor temperature by limiting how much the fake temperature can change between updates. 

### Description
- Added ramp configuration constants to `custom_components/pumpsteer/settings.py` (`RAMP_STEP_BASE`, `RAMP_STEP_PER_AGGRESSIVENESS`, `RAMP_MAX_STEP`, `BRAKE_RAMP_MULTIPLIER`).
- Implemented `_last_fake_temp` state and `_apply_temperature_ramp` in `custom_components/pumpsteer/sensor/sensor.py` to cap per-update temperature steps and make ramp size dependent on `aggressiveness` and mode. 
- Integrated the ramping step into `async_update` so computed `fake_temp` is smoothed before being set as the entity state. 
- Reset ramp state (`_last_fake_temp = None`) when required sensor data is missing to avoid stale ramping after errors. 

### Testing
- Ran `pytest` in the repository root which failed during collection with `ModuleNotFoundError: No module named 'homeassistant'` (tests did not run due to missing Home Assistant test environment).
- Re-ran `pytest` after changes which produced the same `ModuleNotFoundError: No module named 'homeassistant'` error (no tests executed successfully).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6967ad145f20832e9bbe6d38e3269b8c)