### PR TITLE
Allow aggressiveness passthrough at zero

### DIFF
--- a/custom_components/pumpsteer/sensor/sensor.py
+++ b/custom_components/pumpsteer/sensor/sensor.py
@@ -214,10 +214,9 @@ class PumpSteerSensor(Entity):
                 get_state(self.hass, HARDCODED_ENTITIES["summer_threshold_entity"])
             )
             or DEFAULT_SUMMER_THRESHOLD,
-            "aggressiveness": safe_float(
+            "aggressiveness": self._resolve_aggressiveness(
                 get_state(self.hass, HARDCODED_ENTITIES["aggressiveness_entity"])
-            )
-            or DEFAULT_AGGRESSIVENESS,
+            ),
             "inertia": safe_float(
                 get_state(self.hass, HARDCODED_ENTITIES["house_inertia_entity"])
             )
@@ -226,6 +225,14 @@ class PumpSteerSensor(Entity):
                 "hourly_forecast_temperatures_entity"
             ],
         }
+
+    @staticmethod
+    def _resolve_aggressiveness(raw_value: Optional[StateType]) -> float:
+        """Resolve aggressiveness while allowing zero for passthrough mode."""
+        value = safe_float(raw_value)
+        if value is None:
+            return DEFAULT_AGGRESSIVENESS
+        return max(0.0, min(5.0, value))
 
     def _validate_required_data(
         self, sensor_data: Dict[str, Any], prices: List[float]


### PR DESCRIPTION
### Motivation

- The input `input_number.pumpsteer_aggressiveness` should allow `0` to act as a passthrough mode while values `1–5` control braking aggressiveness, but the previous logic replaced falsy `0` with the default aggressiveness.

### Description

- Replace the previous `safe_float(... ) or DEFAULT_AGGRESSIVENESS` usage with a helper to preserve explicit zero values.
- Add a static helper ` _resolve_aggressiveness(raw_value: Optional[StateType]) -> float` which returns `DEFAULT_AGGRESSIVENESS` only when the raw value is `None` and otherwise clamps the value to the `0.0–5.0` range.
- Wire the helper into `_get_sensor_data` so the sensor uses the resolved aggressiveness value during calculations.

### Testing

- Ran `pytest -q`, which could not complete due to an environment dependency error: `ModuleNotFoundError: No module named 'homeassistant'` during test collection, so automated tests did not run successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696d023525c4832e8f7eda484c23cf65)