### PR TITLE
Add price boost preheating based on forecasts

### DIFF
--- a/custom_components/pumpsteer/settings.py
+++ b/custom_components/pumpsteer/settings.py
@@ -32,6 +32,9 @@ WINTER_BRAKE_THRESHOLD: Final[float] = (
 CHEAP_PRICE_OVERSHOOT: Final[float] = (
     1.5  # °C to overshoot target when prices are very cheap
 )
+PRICE_BOOST_OVERSHOOT: Final[float] = (
+    1.0  # °C extra overshoot when preheating ahead of expensive prices
+)
 HEATING_COMPENSATION_FACTOR: Final[float] = (
     0.2  # Factor for lowering fake temp per °C deficit and aggressiveness unit
 )


### PR DESCRIPTION
### Motivation

- Förbättra möjligheten att förvärma huset inför väntat dyra elpriser genom att använda prisprognoser för att aktivera en temporär "price boost" som ökar målvärdet för logiken.

### Description

- Lagt till ny konfigurationskonstant `PRICE_BOOST_OVERSHOOT` i `custom_components/pumpsteer/settings.py` för extra överskjutning vid prisboost.
- Integrerat prognosbaserad analys genom att importera och anropa `async_get_forecast_prices` och `calculate_boost_potential` i `custom_components/pumpsteer/sensor/sensor.py` för att beräkna och markera boost-fönster.
- När boost är aktiv ökas `target_temp_for_logic` med `PRICE_BOOST_OVERSHOOT` i `_calculate_output_temperature` och en loggrad skrivs ut; `boost_active` skickas vidare som parameter.
- Exponerar diagnostik/telemetri i sensorns attribut genom att lägga till `price_boost_active`, `price_boost_reason`, `price_boost_hours`, `price_boost_indices` och `price_boost_savings_potential` i `_build_attributes`.

### Testing

- Körning av `pytest -q` i projektrot kördes efter ändringarna.  
- Testkörningen avbröts under testinsamling med fel `ModuleNotFoundError: No module named 'homeassistant'`, vilket indikerar att testmiljön saknar Home Assistant-stubbar/dependency och därför inte körde enhetstesterna framgångsrikt.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696dc0736710832e98d849b6c9deef9d)