### PR TITLE
Fix ML collector data wiring and shared state

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,7 @@
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+sys.path.append(str(Path(__file__).resolve().parent))
+
+import ha_test_stubs  # noqa: F401

--- a/tests/ha_test_stubs.py
+++ b/tests/ha_test_stubs.py
@@ -106,6 +106,13 @@ def now():
 
 
 dt.now = now
+
+
+def parse_datetime(value):
+    return value
+
+
+dt.parse_datetime = parse_datetime
 util.dt = dt
 sys.modules["homeassistant.util"] = util
 sys.modules["homeassistant.util.dt"] = dt

--- a/tests/test_ml_adaptive.py
+++ b/tests/test_ml_adaptive.py
@@ -1,0 +1,48 @@
+import asyncio
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+sys.path.append(str(Path(__file__).resolve().parent))
+
+from custom_components.pumpsteer.ml_adaptive import PumpSteerMLCollector
+
+
+class DummyHass:
+    def __init__(self):
+        self.data = {}
+
+    async def async_add_executor_job(self, func, *args):
+        return func(*args)
+
+    def async_create_task(self, coro):
+        return asyncio.create_task(coro)
+
+
+def test_end_session_without_target_temp_marks_failure():
+    async def run_test():
+        hass = DummyHass()
+        collector = PumpSteerMLCollector(hass)
+
+        async def async_noop():
+            return None
+
+        collector.async_update_learning_model = async_noop
+        collector.async_save_data = async_noop
+
+        collector.start_session({"mode": "heating"})
+        collector.update_session(
+            {
+                "indoor_temp": 20.0,
+                "outdoor_temp": 5.0,
+                "target_temp": None,
+            }
+        )
+        collector.end_session("normal")
+        await asyncio.sleep(0)
+
+        summary = collector.learning_sessions[-1]["summary"]
+        assert summary["comfort_drift"] is None
+        assert summary["success"] is False
+
+    asyncio.run(run_test())

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -10,7 +10,7 @@ from custom_components.pumpsteer.utils import (
 
 
 def test_get_version_reads_manifest():
-    assert get_version() == "1.6.0"
+    assert get_version() == "1.6.6"
 
 
 def test_get_version_missing_manifest(monkeypatch):


### PR DESCRIPTION
### Motivation
- Fixa mismatch i ML-data som skickas från kontrollsensorn så fältnamn och innehåll matchar vad ML-collectorn förväntar sig (undvik tysta mismatch och felaktiga antaganden om saknad data).
- Förhindra att en session räknas som lyckad när `target_temp` saknas, och undvik att inkludera sådana sessions i regression/träning.
- Undvika att ML-sensorn visar föråldrad data genom att dela en enda `PumpSteerMLCollector`-instans mellan kontrollsensorn och ML-sensorn.
- Flytta potentiellt tunga ML-beräkningar bort från event-loopen och använd konfigurerbara trösklar för att bestämma när träning ska köras.

### Description
- Synkade fältnamn som skickas till ML-collectorn: skickar `fake_outdoor_temp` (inte `fake_temp`), `price_now`, `heating_active`, `heat_demand` och `house_inertia`, och skickar explicit `None` för ej tillgängliga värden där det är applicerbart (`custom_components/pumpsteer/sensor/sensor.py`).
- I sessionssammanfattningen sätts `comfort_drift` till `None` om måltemperatur saknas och `success` markeras som `False` i de fallen; loggutskriften visar `n/a` för drift när den saknas (`custom_components/pumpsteer/ml_adaptive.py`).
- Delad ML-collector: både `PumpSteerSensor` och `PumpSteerMLSensor` sparar/läser samma `PumpSteerMLCollector` i `hass.data` under `hass.data['pumpsteer']['ml_collectors'][entry_id]`, och ägarskap/spårning gjordes så att shutdown endast sker av den instans som skapade collectorn (`custom_components/pumpsteer/sensor/sensor.py`, `custom_components/pumpsteer/sensor/ml_sensor.py`).
- Träning och tunga beräkningar körs nu i executor via `await hass.async_add_executor_job(...)` och `ML_MIN_HEATING_SESSIONS` används som tröskel istället för hårdkodat `5`; sessions med `heating_active == True` inkluderas även om `mode != 'heating'` för att förbättra täckning (`custom_components/pumpsteer/ml_adaptive.py`).
- Mindre test- och stub-justeringar för att spegla nuvarande beteende och version i manifest: la till ett ML-enhetstest och en `conftest.py`, uppdaterade teststubs och ett par test-förväntningar (`tests/test_ml_adaptive.py`, `tests/conftest.py`, `tests/ha_test_stubs.py`, samt uppdaterade testfiler).

### Testing
- Körning av `pytest` i repo visade success: all testsvit körd lokalt med `pytest` och alla tester passerade (`22 passed`).
- Test som lades till: `tests/test_ml_adaptive.py` verifierar att en session utan `target_temp` får `comfort_drift is None` och `success is False`.
- Befintliga enhetstester uppdaterades för att reflektera logikändringar och manifestversion (`tests/test_temperature_vs_price.py`, `tests/test_utils.py`) och kördes framgångsrikt under samma `pytest`-körning.

Verifiering i Home Assistant: lägg märke till att `sensor.pumpsteer_ml_analysis` och `sensor.pumpsteer` nu refererar till samma live-collector och att ML-loggar skrivs under `custom_components.pumpsteer.ml_adaptive` när sessioner avslutas; den delade collectorn finns i `hass.data['pumpsteer']['ml_collectors'][<entry_id>]`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696e3cca6b00832e8e46c94f6452df76)