### PR TITLE
Add PI controllers for predictive price braking and comfort correction

### DIFF
--- a/custom_components/pumpsteer/pi_controller.py
+++ b/custom_components/pumpsteer/pi_controller.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+from statistics import median
+from typing import List, Tuple
+
+
+def select_price_horizon(dt_minutes: int, horizon_15m: int, horizon_hourly: int) -> int:
+    """Select horizon steps based on price resolution."""
+    if dt_minutes > 0 and dt_minutes <= 30:
+        return horizon_15m
+    return horizon_hourly
+
+
+def compute_price_baseline(
+    prices: List[float], start_index: int, window_steps: int
+) -> float:
+    """Compute a median baseline from the upcoming price window."""
+    if not prices or start_index >= len(prices):
+        return 0.0
+    window = prices[start_index : min(len(prices), start_index + window_steps)]
+    return float(median(window)) if window else float(prices[start_index])
+
+
+def compute_price_pressure(
+    prices: List[float], start_index: int, horizon_steps: int, baseline: float
+) -> float:
+    """Compute a weighted positive price pressure over the horizon."""
+    if not prices or horizon_steps <= 0 or start_index >= len(prices):
+        return 0.0
+
+    horizon = min(horizon_steps, len(prices) - start_index)
+    total = 0.0
+    for offset in range(horizon):
+        price = prices[start_index + offset]
+        weight = (horizon_steps - offset) / horizon_steps
+        total += weight * max(price - baseline, 0.0)
+    return total
+
+
+def update_pi_output(
+    value: float,
+    integral: float,
+    kp: float,
+    ki: float,
+    dt_hours: float,
+    output_min: float,
+    output_max: float,
+) -> Tuple[float, float, bool, bool]:
+    """Update PI output with basic anti-windup."""
+    proportional = kp * value
+    candidate_integral = integral + ki * value * dt_hours
+    raw = proportional + candidate_integral
+
+    saturated_high = raw > output_max
+    saturated_low = raw < output_min
+
+    if (saturated_high and value > 0) or (saturated_low and value < 0):
+        candidate_integral = integral
+        raw = proportional + candidate_integral
+
+    clamped = max(output_min, min(output_max, raw))
+    return clamped, candidate_integral, saturated_high, saturated_low
+
+
+def apply_rate_limit(
+    desired: float, last: float | None, max_delta: float
+) -> Tuple[float, bool]:
+    """Apply a symmetric rate limit between successive outputs."""
+    if last is None:
+        return desired, False
+    delta = desired - last
+    if abs(delta) <= max_delta:
+        return desired, False
+    limited = last + max_delta * (1 if delta > 0 else -1)
+    return limited, True

--- a/custom_components/pumpsteer/settings.py
+++ b/custom_components/pumpsteer/settings.py
@@ -31,6 +31,22 @@ BRAKING_COMPENSATION_FACTOR: Final[float] = (
     0.4  # Factor for raising fake temp per °C surplus and aggressiveness unit
 )
 
+# === PI CONTROL SETTINGS ===
+PRICE_PI_KP: Final[float] = 0.12
+PRICE_PI_KI: Final[float] = 0.04
+PRICE_HORIZON_STEPS_15M: Final[int] = 8
+PRICE_HORIZON_STEPS_HOURLY: Final[int] = 6
+PRICE_MAX_DELTA_PER_STEP: Final[float] = 0.08
+
+COMFORT_PI_KP: Final[float] = 0.6
+COMFORT_PI_KI: Final[float] = 0.1
+COMFORT_DEADBAND: Final[float] = 0.1
+
+BRAKE_WEIGHT: Final[float] = 1.0
+GAS_WEIGHT: Final[float] = 0.8
+COMFORT_BACKOFF_WEIGHT: Final[float] = 0.5
+CONTROL_BIAS_TEMP_SCALE: Final[float] = 1.5
+
 # === COMFORT CONTROL SETTINGS ===
 # Defines when the system considers the indoor temperature "too cold"
 # to allow price braking. Previously hardcoded as -0.5 °C inside the logic.

--- a/tests/test_const.py
+++ b/tests/test_const.py
@@ -40,6 +40,19 @@ def test_build_attributes_basic():
     s = sensor.PumpSteerSensor(DummyHass(), DummyConfigEntry())
     s._state = 5.0
 
+    pi_data = {
+        "price_brake_level": 0.0,
+        "price_pressure": 0.0,
+        "price_baseline": 0.0,
+        "price_horizon": 6,
+        "price_I": 0.0,
+        "price_rate_limited": False,
+        "comfort_push": 0.0,
+        "comfort_I": 0.0,
+        "temp_error": 0.0,
+        "dt_minutes": 60,
+    }
+
     attrs = s._build_attributes(
         sensor_data,
         prices,
@@ -51,6 +64,8 @@ def test_build_attributes_basic():
         now_hour,
         price_interval_minutes=60,
         current_slot_index=0,
+        pi_data=pi_data,
+        final_adjust=0.0,
     )
     assert attrs["mode"] == "heating"
     assert attrs["current_price"] == 1.2
@@ -79,6 +94,19 @@ def test_decision_reason_very_cheap_heating():
     s = sensor.PumpSteerSensor(DummyHass(), DummyConfigEntry())
     s._state = 5.0
 
+    pi_data = {
+        "price_brake_level": 0.0,
+        "price_pressure": 0.0,
+        "price_baseline": 0.0,
+        "price_horizon": 6,
+        "price_I": 0.0,
+        "price_rate_limited": False,
+        "comfort_push": 0.0,
+        "comfort_I": 0.0,
+        "temp_error": 0.0,
+        "dt_minutes": 60,
+    }
+
     attrs = s._build_attributes(
         sensor_data,
         prices,
@@ -90,6 +118,8 @@ def test_decision_reason_very_cheap_heating():
         now_hour,
         price_interval_minutes=60,
         current_slot_index=0,
+        pi_data=pi_data,
+        final_adjust=0.0,
     )
     assert attrs["decision_reason"] == "heating - Triggered by very cheap price"
 
@@ -115,6 +145,19 @@ def test_decision_reason_precool():
     s = sensor.PumpSteerSensor(DummyHass(), DummyConfigEntry())
     s._state = 5.0
 
+    pi_data = {
+        "price_brake_level": 0.0,
+        "price_pressure": 0.0,
+        "price_baseline": 0.0,
+        "price_horizon": 6,
+        "price_I": 0.0,
+        "price_rate_limited": False,
+        "comfort_push": 0.0,
+        "comfort_I": 0.0,
+        "temp_error": 0.0,
+        "dt_minutes": 60,
+    }
+
     attrs = s._build_attributes(
         sensor_data,
         prices,
@@ -126,5 +169,7 @@ def test_decision_reason_precool():
         now_hour,
         price_interval_minutes=60,
         current_slot_index=0,
+        pi_data=pi_data,
+        final_adjust=0.0,
     )
     assert attrs["decision_reason"] == "precool - Triggered by pre-cool (warm forecast)"

--- a/tests/test_pi_controller.py
+++ b/tests/test_pi_controller.py
@@ -1,0 +1,62 @@
+from custom_components.pumpsteer.pi_controller import (
+    apply_rate_limit,
+    compute_price_baseline,
+    compute_price_pressure,
+    update_pi_output,
+)
+
+
+def test_price_pressure_longer_peak_is_stronger():
+    baseline = 1.0
+    short_spike = [1.0, 1.0, 5.0, 1.0, 1.0, 1.0]
+    long_peak = [1.0, 5.0, 5.0, 5.0, 5.0, 5.0]
+
+    short_pressure = compute_price_pressure(short_spike, 0, 6, baseline)
+    long_pressure = compute_price_pressure(long_peak, 0, 6, baseline)
+
+    assert long_pressure > short_pressure
+
+
+def test_price_baseline_uses_median_window():
+    prices = [1.0, 1.2, 5.0, 1.1, 1.0]
+    baseline = compute_price_baseline(prices, 0, 5)
+
+    assert baseline == 1.1
+
+
+def test_price_rate_limit_caps_change():
+    limited, rate_limited = apply_rate_limit(0.6, 0.0, 0.1)
+
+    assert limited == 0.1
+    assert rate_limited is True
+
+
+def test_comfort_pi_integrates_and_clamps():
+    output, integral, saturated_high, saturated_low = update_pi_output(
+        value=1.0,
+        integral=0.0,
+        kp=0.6,
+        ki=0.1,
+        dt_hours=1.0,
+        output_min=-1.0,
+        output_max=1.0,
+    )
+
+    assert output > 0.6
+    assert integral > 0.0
+    assert not saturated_high
+    assert not saturated_low
+
+    output, integral, saturated_high, _ = update_pi_output(
+        value=10.0,
+        integral=integral,
+        kp=0.6,
+        ki=0.1,
+        dt_hours=1.0,
+        output_min=-1.0,
+        output_max=1.0,
+    )
+
+    assert output == 1.0
+    assert saturated_high
+    assert integral < 2.0


### PR DESCRIPTION
### Motivation
- Introduce a predictive PRICE PI and a COMFORT PI to create a continuous, smooth brake/gas signal from future price pressure while preventing comfort drift.
- Make aggressiveness remain the user dial that scales allowed adjustments while ensuring comfort protection and robustness to short price spikes.

### Description
- Add shared PI controller utilities in `custom_components/pumpsteer/pi_controller.py` providing horizon selection, median baseline, weighted future price pressure, PI update with anti-windup, and symmetric rate limiting. 
- Add conservative PI tuning and combination constants to `custom_components/pumpsteer/settings.py` (price/comfort Kp/Ki, horizons for 15m/hourly resolution, max delta per step, deadband, weights and a temperature bias scale). 
- Integrate PI logic into `PumpSteerSensor` (`custom_components/pumpsteer/sensor/sensor.py`) to: compute combined today+tomorrow prices, calculate price pressure and baseline, run PRICE PI (0..1) with integral and rate-limit, run COMFORT PI (-1..1) with deadband and anti-windup, combine gas/brake/backoff via weights and aggressiveness factor into a continuous `final_adjust`, convert that to a continuous fake-temperature bias and expose observability attributes. 
- Expose observability attributes and controlled debug logging on the main sensor (e.g. `price_brake_level`, `price_pressure`, `price_baseline`, `price_horizon`, PI params and integrators, `comfort_push`, `temp_error`, `final_adjust`, `dt_minutes`, `price_rate_limited`). 
- Add unit tests `tests/test_pi_controller.py` covering pressure calculation, baseline median, rate limiting and basic PI behaviour, and update existing test expectations to match the new sensor attribute/API shape. 

### Testing
- Ran `ruff check`, which passed. 
- Ran `ruff format --check` and formatted affected files; format check passed after reformatting. 
- Ran `pytest tests/ -v`, which could not complete due to the test environment missing the `homeassistant` dependency (`ModuleNotFoundError: No module named 'homeassistant'`), so full test collection/execution was blocked in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696e48aebca4832ea44761783edff768)