### PR TITLE
Centralize constants in const.py, update imports, and add import check script

### DIFF
--- a/custom_components/pumpsteer/config_flow.py
+++ b/custom_components/pumpsteer/config_flow.py
@@ -6,23 +6,12 @@ from homeassistant.core import callback
 from homeassistant.helpers.selector import selector
 from homeassistant.const import STATE_UNAVAILABLE, STATE_UNKNOWN
 
+from .const import HARDCODED_ENTITIES
 from .options_flow import PumpSteerOptionsFlowHandler
 
 _LOGGER = logging.getLogger(__name__)
 
 DOMAIN = "pumpsteer"
-
-# Hardcoded entities that are always present in the package file
-HARDCODED_ENTITIES = {
-    "target_temp_entity": "input_number.indoor_target_temperature",
-    "summer_threshold_entity": "input_number.pumpsteer_summer_threshold",
-    "holiday_mode_boolean_entity": "input_boolean.holiday_mode",
-    "holiday_start_datetime_entity": "input_datetime.holiday_start",
-    "holiday_end_datetime_entity": "input_datetime.holiday_end",
-    "auto_tune_inertia_entity": "input_boolean.autotune_inertia",
-    "hourly_forecast_temperatures_entity": "input_text.hourly_forecast_temperatures",
-}
-
 
 class PumpSteerConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     """Handle a config flow for pumpsteer"""

--- a/custom_components/pumpsteer/const.py
+++ b/custom_components/pumpsteer/const.py
@@ -1,1 +1,142 @@
-DOMAIN = "pumpsteer"
+"""Constants for the PumpSteer integration."""
+
+from typing import Final, List, Optional
+
+DOMAIN: Final[str] = "pumpsteer"
+
+PUMPSTEER_VERSION: Final[str] = "1.2.1"
+DEFAULT_HOUSE_INERTIA: Final[float] = 1.0
+HOLIDAY_TEMP: Final[float] = 16.0
+BRAKING_MODE_TEMP: Final[float] = 19.0
+AGGRESSIVENESS_SCALING_FACTOR: Final[float] = 0.5
+
+HARDCODED_ENTITIES: Final[dict[str, str]] = {
+    "target_temp_entity": "input_number.indoor_target_temperature",
+    "summer_threshold_entity": "input_number.pumpsteer_summer_threshold",
+    "holiday_mode_boolean_entity": "input_boolean.holiday_mode",
+    "holiday_start_datetime_entity": "input_datetime.holiday_start",
+    "holiday_end_datetime_entity": "input_datetime.holiday_end",
+    "auto_tune_inertia_entity": "input_boolean.autotune_inertia",
+    "hourly_forecast_temperatures_entity": "input_text.hourly_forecast_temperatures",
+    "aggressiveness_entity": "input_number.pumpsteer_aggressiveness",
+    "house_inertia_entity": "input_number.house_inertia",
+    "price_model_entity": "input_select.pumpsteer_price_model",
+}
+
+MIN_FAKE_TEMP: Final[float] = -25.0
+MAX_FAKE_TEMP: Final[float] = 25.0
+BRAKE_FAKE_TEMP: Final[float] = 25.0
+PRECOOL_LOOKAHEAD: Final[int] = 24  # Hours ahead to look for precooling
+PRECOOL_MARGIN: Final[float] = 3.0  # °C margin added to summer threshold for precooling
+WINTER_BRAKE_TEMP_OFFSET: Final[float] = (
+    10.0  # °C offset above outdoor temp when braking in winter
+)
+WINTER_BRAKE_THRESHOLD: Final[float] = (
+    7.0  # °C threshold for applying winter brake offset
+)
+CHEAP_PRICE_OVERSHOOT: Final[float] = (
+    1.5  # °C to overshoot target when prices are very cheap
+)
+HEATING_COMPENSATION_FACTOR: Final[float] = (
+    0.2  # Factor for lowering fake temp per °C deficit and aggressiveness unit
+)
+BRAKING_COMPENSATION_FACTOR: Final[float] = (
+    0.4  # Factor for raising fake temp per °C surplus and aggressiveness unit
+)
+
+# === PI CONTROL SETTINGS ===
+PRICE_PI_KP: Final[float] = 0.12
+PRICE_PI_KI: Final[float] = 0.04
+PRICE_HORIZON_STEPS_15M: Final[int] = 8
+PRICE_HORIZON_STEPS_HOURLY: Final[int] = 6
+PRICE_MAX_DELTA_PER_STEP: Final[float] = 0.08
+PRICE_BRAKE_MAX_DELTA_PER_STEP: Final[float] = 0.08
+MPC_HORIZON_STEPS: Final[int] = 6
+MPC_PRICE_WEIGHT: Final[float] = 1.0
+MPC_COMFORT_WEIGHT: Final[float] = 1.0
+MPC_SMOOTH_WEIGHT: Final[float] = 1.0
+
+# === PRICE BRAKE BLOCK SETTINGS ===
+MIN_BLOCK_DURATION_MIN: Final[int] = 60
+PRICE_BLOCK_THRESHOLD_DELTA: Final[float] = 0.3
+PRICE_BLOCK_THRESHOLD_PERCENTILE: Final[Optional[float]] = None
+PRICE_BRAKE_PRE_MINUTES: Final[int] = 60
+PRICE_BRAKE_POST_MINUTES: Final[int] = 60
+PRICE_BLOCK_AREA_SCALE: Final[float] = 4.0
+
+COMFORT_PI_KP: Final[float] = 0.6
+COMFORT_PI_KI: Final[float] = 0.1
+COMFORT_DEADBAND: Final[float] = 0.1
+
+BRAKE_WEIGHT: Final[float] = 1.0
+GAS_WEIGHT: Final[float] = 0.8
+COMFORT_BACKOFF_WEIGHT: Final[float] = 0.5
+CONTROL_BIAS_TEMP_SCALE: Final[float] = 1.5
+
+# === COMFORT CONTROL SETTINGS ===
+# Defines when the system considers the indoor temperature "too cold"
+# to allow price braking. Previously hardcoded as -0.5 °C inside the logic.
+#
+# If indoor_temp - target_temp < HEATING_THRESHOLD:
+#     → PumpSteer enters heating mode regardless of price.
+#
+# Increasing the value to -1.0 or -1.5 allows more price braking
+# even when the house is below the target temperature.
+
+HEATING_THRESHOLD: Final[float] = -1.5  # °C
+
+# === ELECTRICITY PRICE CLASSIFICATION ===
+DEFAULT_PERCENTILES: Final[List[int]] = [
+    10,
+    30,
+    85,
+    95,
+]
+
+DEFAULT_EXTREME_MULTIPLIER: Final[float] = 1.5
+MIN_SAMPLES_FOR_CLASSIFICATION: Final[int] = 5
+
+PRICE_CATEGORIES: Final[List[str]] = [
+    "very_cheap",
+    "cheap",
+    "normal",
+    "expensive",
+    "very_expensive",
+    "extreme",
+]
+
+ABSOLUTE_CHEAP_LIMIT: Final[float] = 0.60  # SEK/kWh
+DEFAULT_TRAILING_HOURS: Final[int] = 72  # Hours of historical data to consider
+MAX_PRICE_WARNING_THRESHOLD: Final[float] = (
+    3.0  # SEK/kWh - Log warning for extremely high prices
+)
+
+VERY_CHEAP_MULTIPLIER: Final[float] = 0.60
+CHEAP_MULTIPLIER: Final[float] = 0.90
+NORMAL_MULTIPLIER: Final[float] = 1.40
+EXPENSIVE_MULTIPLIER: Final[float] = 2.00
+VERY_EXPENSIVE_MULTIPLIER: Final[float] = 3.00
+
+# === EXPLANATION OF DESIGN DECISIONS ===
+
+# 1. EXTREME CATEGORY: YES
+# - Prices over 300% of average get "extreme" classification
+# - Useful for identifying truly exceptional price spikes
+# - Helps differentiate between "very expensive" and "crisis level" pricing
+
+# 2. ABSOLUTE_CHEAP_LIMIT: YES, KEEP AT 0.60 SEK/kWh
+# - Still relevant as safety net for hybrid classification
+# - Ensures that genuinely cheap absolute prices aren't missed
+# - Example: If average is 2.00 SEK/kWh, 90% would be 1.80 SEK/kWh
+#   But a price of 0.50 SEK/kWh should still be "cheap" regardless
+
+# 3. HYBRID RULE: YES, KEEP IT
+# - Allows absolute thresholds to override relative classification
+# - Provides more intuitive results for users
+# - Prevents situations where objectively cheap prices are classified as "normal"
+#   just because the recent average was very low
+
+MIN_REASONABLE_TEMP: Final[float] = -50.0
+MAX_REASONABLE_TEMP: Final[float] = 50.0
+MIN_REASONABLE_PRICE: Final[float] = -2.0  # SEK/kWh
+MAX_REASONABLE_PRICE: Final[float] = 15.0  # SEK/kWh

--- a/custom_components/pumpsteer/electricity_price.py
+++ b/custom_components/pumpsteer/electricity_price.py
@@ -8,7 +8,7 @@ from homeassistant.components.recorder.history import get_significant_states
 from homeassistant.core import HomeAssistant
 from homeassistant.util.dt import now as dt_now
 
-from .settings import (
+from .const import (
     ABSOLUTE_CHEAP_LIMIT,
     CHEAP_MULTIPLIER,
     DEFAULT_EXTREME_MULTIPLIER,

--- a/custom_components/pumpsteer/holiday.py
+++ b/custom_components/pumpsteer/holiday.py
@@ -3,7 +3,7 @@ import logging
 from homeassistant.core import HomeAssistant
 from homeassistant.util.dt import parse_datetime
 from homeassistant.const import STATE_ON
-from .settings import HOLIDAY_TEMP
+from .const import HOLIDAY_TEMP
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/custom_components/pumpsteer/options_flow.py
+++ b/custom_components/pumpsteer/options_flow.py
@@ -5,21 +5,11 @@ from homeassistant import config_entries
 from homeassistant.helpers.selector import selector
 from homeassistant.const import STATE_UNAVAILABLE, STATE_UNKNOWN
 
-from .settings import PRICE_BLOCK_THRESHOLD_DELTA
+from .const import HARDCODED_ENTITIES, PRICE_BLOCK_THRESHOLD_DELTA
 
 _LOGGER = logging.getLogger(__name__)
 
 DOMAIN = "pumpsteer"
-
-HARDCODED_ENTITIES = {
-    "target_temp_entity": "input_number.indoor_target_temperature",
-    "summer_threshold_entity": "input_number.pumpsteer_summer_threshold",
-    "holiday_mode_boolean_entity": "input_boolean.holiday_mode",
-    "holiday_start_datetime_entity": "input_datetime.holiday_start",
-    "holiday_end_datetime_entity": "input_datetime.holiday_end",
-    "auto_tune_inertia_entity": "input_boolean.autotune_inertia",
-    "hourly_forecast_temperatures_entity": "input_text.hourly_forecast_temperatures",
-}
 
 
 class PumpSteerOptionsFlowHandler(config_entries.OptionsFlow):

--- a/custom_components/pumpsteer/sensor/sensor.py
+++ b/custom_components/pumpsteer/sensor/sensor.py
@@ -14,7 +14,7 @@ import homeassistant.util.dt as dt_util
 from ..holiday import is_holiday_mode_active
 from ..temp_control_logic import calculate_temperature_output
 from ..electricity_price import async_hybrid_classify_with_history, classify_prices
-from ..settings import (
+from ..const import (
     DEFAULT_HOUSE_INERTIA,
     HOLIDAY_TEMP,
     BRAKE_FAKE_TEMP,
@@ -39,6 +39,7 @@ from ..settings import (
     PRICE_BRAKE_PRE_MINUTES,
     PRICE_BRAKE_POST_MINUTES,
     PRICE_BLOCK_AREA_SCALE,
+    HARDCODED_ENTITIES,
 )
 from ..pi_controller import (
     apply_rate_limit,
@@ -71,19 +72,6 @@ except ImportError as e:
 DOMAIN = "pumpsteer"
 
 SW_VERSION = get_version()
-
-# Hardcoded entities
-HARDCODED_ENTITIES = {
-    "target_temp_entity": "input_number.indoor_target_temperature",
-    "summer_threshold_entity": "input_number.pumpsteer_summer_threshold",
-    "holiday_mode_boolean_entity": "input_boolean.holiday_mode",
-    "holiday_start_datetime_entity": "input_datetime.holiday_start",
-    "holiday_end_datetime_entity": "input_datetime.holiday_end",
-    "hourly_forecast_temperatures_entity": "input_text.hourly_forecast_temperatures",
-    "aggressiveness_entity": "input_number.pumpsteer_aggressiveness",
-    "house_inertia_entity": "input_number.house_inertia",
-    "price_model_entity": "input_select.pumpsteer_price_model",
-}
 
 NEUTRAL_TEMP_THRESHOLD = 0.5
 DEFAULT_SUMMER_THRESHOLD = 18.0

--- a/custom_components/pumpsteer/settings.py
+++ b/custom_components/pumpsteer/settings.py
@@ -1,136 +1,130 @@
-from typing import List, Final, Optional
+"""Compatibility settings module for PumpSteer."""
+
 import logging
+
+from .const import (
+    ABSOLUTE_CHEAP_LIMIT,
+    AGGRESSIVENESS_SCALING_FACTOR,
+    BRAKE_FAKE_TEMP,
+    BRAKE_WEIGHT,
+    BRAKING_COMPENSATION_FACTOR,
+    BRAKING_MODE_TEMP,
+    CHEAP_MULTIPLIER,
+    CHEAP_PRICE_OVERSHOOT,
+    COMFORT_BACKOFF_WEIGHT,
+    COMFORT_DEADBAND,
+    COMFORT_PI_KI,
+    COMFORT_PI_KP,
+    CONTROL_BIAS_TEMP_SCALE,
+    DEFAULT_EXTREME_MULTIPLIER,
+    DEFAULT_HOUSE_INERTIA,
+    DEFAULT_PERCENTILES,
+    DEFAULT_TRAILING_HOURS,
+    EXPENSIVE_MULTIPLIER,
+    GAS_WEIGHT,
+    HARDCODED_ENTITIES,
+    HEATING_COMPENSATION_FACTOR,
+    HEATING_THRESHOLD,
+    HOLIDAY_TEMP,
+    MAX_FAKE_TEMP,
+    MAX_PRICE_WARNING_THRESHOLD,
+    MAX_REASONABLE_PRICE,
+    MAX_REASONABLE_TEMP,
+    MIN_BLOCK_DURATION_MIN,
+    MIN_FAKE_TEMP,
+    MIN_REASONABLE_PRICE,
+    MIN_REASONABLE_TEMP,
+    MIN_SAMPLES_FOR_CLASSIFICATION,
+    MPC_COMFORT_WEIGHT,
+    MPC_HORIZON_STEPS,
+    MPC_PRICE_WEIGHT,
+    MPC_SMOOTH_WEIGHT,
+    NORMAL_MULTIPLIER,
+    PRECOOL_LOOKAHEAD,
+    PRECOOL_MARGIN,
+    PRICE_BLOCK_AREA_SCALE,
+    PRICE_BLOCK_THRESHOLD_DELTA,
+    PRICE_BLOCK_THRESHOLD_PERCENTILE,
+    PRICE_BRAKE_MAX_DELTA_PER_STEP,
+    PRICE_BRAKE_POST_MINUTES,
+    PRICE_BRAKE_PRE_MINUTES,
+    PRICE_CATEGORIES,
+    PRICE_HORIZON_STEPS_15M,
+    PRICE_HORIZON_STEPS_HOURLY,
+    PRICE_MAX_DELTA_PER_STEP,
+    PRICE_PI_KI,
+    PRICE_PI_KP,
+    PUMPSTEER_VERSION,
+    VERY_CHEAP_MULTIPLIER,
+    VERY_EXPENSIVE_MULTIPLIER,
+    WINTER_BRAKE_TEMP_OFFSET,
+    WINTER_BRAKE_THRESHOLD,
+)
 
 _LOGGER = logging.getLogger(__name__)
 
-PUMPSTEER_VERSION: Final[str] = "1.2.1"
-DEFAULT_HOUSE_INERTIA: Final[float] = 1.0
-HOLIDAY_TEMP: Final[float] = 16.0
-BRAKING_MODE_TEMP: Final[float] = 19.0
-AGGRESSIVENESS_SCALING_FACTOR: Final[float] = 0.5
-
-
-MIN_FAKE_TEMP: Final[float] = -25.0
-MAX_FAKE_TEMP: Final[float] = 25.0
-BRAKE_FAKE_TEMP: Final[float] = 25.0
-PRECOOL_LOOKAHEAD: Final[int] = 24  # Hours ahead to look for precooling
-PRECOOL_MARGIN: Final[float] = 3.0  # °C margin added to summer threshold for precooling
-WINTER_BRAKE_TEMP_OFFSET: Final[float] = (
-    10.0  # °C offset above outdoor temp when braking in winter
-)
-WINTER_BRAKE_THRESHOLD: Final[float] = (
-    7.0  # °C threshold for applying winter brake offset
-)
-CHEAP_PRICE_OVERSHOOT: Final[float] = (
-    1.5  # °C to overshoot target when prices are very cheap
-)
-HEATING_COMPENSATION_FACTOR: Final[float] = (
-    0.2  # Factor for lowering fake temp per °C deficit and aggressiveness unit
-)
-BRAKING_COMPENSATION_FACTOR: Final[float] = (
-    0.4  # Factor for raising fake temp per °C surplus and aggressiveness unit
-)
-
-# === PI CONTROL SETTINGS ===
-PRICE_PI_KP: Final[float] = 0.12
-PRICE_PI_KI: Final[float] = 0.04
-PRICE_HORIZON_STEPS_15M: Final[int] = 8
-PRICE_HORIZON_STEPS_HOURLY: Final[int] = 6
-PRICE_MAX_DELTA_PER_STEP: Final[float] = 0.08
-PRICE_BRAKE_MAX_DELTA_PER_STEP: Final[float] = 0.08
-MPC_HORIZON_STEPS: Final[int] = 6
-MPC_PRICE_WEIGHT: Final[float] = 1.0
-
-# === PRICE BRAKE BLOCK SETTINGS ===
-MIN_BLOCK_DURATION_MIN: Final[int] = 60
-PRICE_BLOCK_THRESHOLD_DELTA: Final[float] = 0.3
-PRICE_BLOCK_THRESHOLD_PERCENTILE: Final[Optional[float]] = None
-PRICE_BRAKE_PRE_MINUTES: Final[int] = 60
-PRICE_BRAKE_POST_MINUTES: Final[int] = 60
-PRICE_BLOCK_AREA_SCALE: Final[float] = 4.0
-
-COMFORT_PI_KP: Final[float] = 0.6
-COMFORT_PI_KI: Final[float] = 0.1
-COMFORT_DEADBAND: Final[float] = 0.1
-
-BRAKE_WEIGHT: Final[float] = 1.0
-GAS_WEIGHT: Final[float] = 0.8
-COMFORT_BACKOFF_WEIGHT: Final[float] = 0.5
-CONTROL_BIAS_TEMP_SCALE: Final[float] = 1.5
-
-# === COMFORT CONTROL SETTINGS ===
-# Defines when the system considers the indoor temperature "too cold"
-# to allow price braking. Previously hardcoded as -0.5 °C inside the logic.
-#
-# If indoor_temp - target_temp < HEATING_THRESHOLD:
-#     → PumpSteer enters heating mode regardless of price.
-#
-# Increasing the value to -1.0 or -1.5 allows more price braking
-# even when the house is below the target temperature.
-
-HEATING_THRESHOLD: Final[float] = -1.5  # °C
-
-# === ELECTRICITY PRICE CLASSIFICATION ===
-DEFAULT_PERCENTILES: Final[List[int]] = [
-    10,
-    30,
-    85,
-    95,
+__all__ = [
+    "ABSOLUTE_CHEAP_LIMIT",
+    "AGGRESSIVENESS_SCALING_FACTOR",
+    "BRAKE_FAKE_TEMP",
+    "BRAKE_WEIGHT",
+    "BRAKING_COMPENSATION_FACTOR",
+    "BRAKING_MODE_TEMP",
+    "CHEAP_MULTIPLIER",
+    "CHEAP_PRICE_OVERSHOOT",
+    "COMFORT_BACKOFF_WEIGHT",
+    "COMFORT_DEADBAND",
+    "COMFORT_PI_KI",
+    "COMFORT_PI_KP",
+    "CONTROL_BIAS_TEMP_SCALE",
+    "DEFAULT_EXTREME_MULTIPLIER",
+    "DEFAULT_HOUSE_INERTIA",
+    "DEFAULT_PERCENTILES",
+    "DEFAULT_TRAILING_HOURS",
+    "EXPENSIVE_MULTIPLIER",
+    "GAS_WEIGHT",
+    "HARDCODED_ENTITIES",
+    "HEATING_COMPENSATION_FACTOR",
+    "HEATING_THRESHOLD",
+    "HOLIDAY_TEMP",
+    "MAX_FAKE_TEMP",
+    "MAX_PRICE_WARNING_THRESHOLD",
+    "MAX_REASONABLE_PRICE",
+    "MAX_REASONABLE_TEMP",
+    "MIN_BLOCK_DURATION_MIN",
+    "MIN_FAKE_TEMP",
+    "MIN_REASONABLE_PRICE",
+    "MIN_REASONABLE_TEMP",
+    "MIN_SAMPLES_FOR_CLASSIFICATION",
+    "MPC_COMFORT_WEIGHT",
+    "MPC_HORIZON_STEPS",
+    "MPC_PRICE_WEIGHT",
+    "MPC_SMOOTH_WEIGHT",
+    "NORMAL_MULTIPLIER",
+    "PRECOOL_LOOKAHEAD",
+    "PRECOOL_MARGIN",
+    "PRICE_BLOCK_AREA_SCALE",
+    "PRICE_BLOCK_THRESHOLD_DELTA",
+    "PRICE_BLOCK_THRESHOLD_PERCENTILE",
+    "PRICE_BRAKE_MAX_DELTA_PER_STEP",
+    "PRICE_BRAKE_POST_MINUTES",
+    "PRICE_BRAKE_PRE_MINUTES",
+    "PRICE_CATEGORIES",
+    "PRICE_HORIZON_STEPS_15M",
+    "PRICE_HORIZON_STEPS_HOURLY",
+    "PRICE_MAX_DELTA_PER_STEP",
+    "PRICE_PI_KI",
+    "PRICE_PI_KP",
+    "PUMPSTEER_VERSION",
+    "VERY_CHEAP_MULTIPLIER",
+    "VERY_EXPENSIVE_MULTIPLIER",
+    "WINTER_BRAKE_TEMP_OFFSET",
+    "WINTER_BRAKE_THRESHOLD",
 ]
-
-DEFAULT_EXTREME_MULTIPLIER: Final[float] = 1.5
-MIN_SAMPLES_FOR_CLASSIFICATION: Final[int] = 5
-
-PRICE_CATEGORIES: Final[List[str]] = [
-    "very_cheap",
-    "cheap",
-    "normal",
-    "expensive",
-    "very_expensive",
-    "extreme",
-]
-
-ABSOLUTE_CHEAP_LIMIT: Final[float] = 0.60  # SEK/kWh
-DEFAULT_TRAILING_HOURS: Final[int] = 72  # Hours of historical data to consider
-MAX_PRICE_WARNING_THRESHOLD: Final[float] = (
-    3.0  # SEK/kWh - Log warning for extremely high prices
-)
-
-
-VERY_CHEAP_MULTIPLIER: Final[float] = 0.60
-CHEAP_MULTIPLIER: Final[float] = 0.90
-NORMAL_MULTIPLIER: Final[float] = 1.40
-EXPENSIVE_MULTIPLIER: Final[float] = 2.00
-VERY_EXPENSIVE_MULTIPLIER: Final[float] = 3.00
-
-# === EXPLANATION OF DESIGN DECISIONS ===
-
-# 1. EXTREME CATEGORY: YES
-# - Prices over 300% of average get "extreme" classification
-# - Useful for identifying truly exceptional price spikes
-# - Helps differentiate between "very expensive" and "crisis level" pricing
-
-# 2. ABSOLUTE_CHEAP_LIMIT: YES, KEEP AT 0.60 SEK/kWh
-# - Still relevant as safety net for hybrid classification
-# - Ensures that genuinely cheap absolute prices aren't missed
-# - Example: If average is 2.00 SEK/kWh, 90% would be 1.80 SEK/kWh
-#   But a price of 0.50 SEK/kWh should still be "cheap" regardless
-
-# 3. HYBRID RULE: YES, KEEP IT
-# - Allows absolute thresholds to override relative classification
-# - Provides more intuitive results for users
-# - Prevents situations where objectively cheap prices are classified as "normal"
-#   just because the recent average was very low
-
-
-MIN_REASONABLE_TEMP: Final[float] = -50.0
-MAX_REASONABLE_TEMP: Final[float] = 50.0
-MIN_REASONABLE_PRICE: Final[float] = -2.0  # SEK/kWh
-MAX_REASONABLE_PRICE: Final[float] = 15.0  # SEK/kWh
 
 
 def validate_core_settings() -> None:
-    """Validate core settings for consistency and logical values"""
+    """Validate core settings for consistency and logical values."""
     errors = []
 
     # Validate percentiles

--- a/custom_components/pumpsteer/temp_control_logic.py
+++ b/custom_components/pumpsteer/temp_control_logic.py
@@ -1,6 +1,6 @@
 import logging
 
-from .settings import (
+from .const import (
     MIN_FAKE_TEMP,
     MAX_FAKE_TEMP,
     HEATING_COMPENSATION_FACTOR,

--- a/custom_components/pumpsteer/utils.py
+++ b/custom_components/pumpsteer/utils.py
@@ -8,7 +8,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.const import STATE_UNAVAILABLE, STATE_UNKNOWN
 from homeassistant.helpers.typing import StateType
 
-from .settings import (
+from .const import (
     MIN_REASONABLE_TEMP,
     MAX_REASONABLE_TEMP,
     MIN_REASONABLE_PRICE,

--- a/tools/import_check.py
+++ b/tools/import_check.py
@@ -1,0 +1,40 @@
+"""Import checks for the PumpSteer integration."""
+
+from __future__ import annotations
+
+import importlib
+import sys
+from pathlib import Path
+
+
+MODULES_TO_CHECK = [
+    "custom_components.pumpsteer",
+    "custom_components.pumpsteer.config_flow",
+    "custom_components.pumpsteer.sensor",
+    "custom_components.pumpsteer.temp_control_logic",
+]
+
+
+def main() -> None:
+    """Import configured modules and fail fast on errors."""
+    failures: list[str] = []
+
+    repo_root = Path(__file__).resolve().parents[1]
+    sys.path.insert(0, str(repo_root))
+
+    for module_name in MODULES_TO_CHECK:
+        try:
+            importlib.import_module(module_name)
+        except ImportError as exc:
+            failures.append(f"{module_name}: {exc}")
+
+    if failures:
+        for failure in failures:
+            print(f"Import check failed: {failure}", file=sys.stderr)
+        raise SystemExit(1)
+
+    print("Import check passed.")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
### Motivation
- Åtgärda tidigare `ImportError` genom att centralisera hårdkodade enheter och övriga shared-konstanter i `custom_components/pumpsteer/const.py` så att alla moduler använder en enda källa.
- Behåll bakåtkompatibilitet genom att ha `settings.py` som kompatibilitetslager som importerar och re-exporterar de vanligaste symbolerna.
- Inför ett enkelt import-check så att saknade importfel fångas tidigt under utveckling/test.

### Description
- Added a new `custom_components/pumpsteer/const.py` containing `HARDCODED_ENTITIES` and the control/price/constants used across the integration. 
- Updated modules to import shared symbols from `const.py` (notably `config_flow.py`, `options_flow.py`, `sensor/sensor.py`, `utils.py`, `holiday.py`, `electricity_price.py`, and `temp_control_logic.py`) and removed duplicate local constant definitions. 
- Reworked `settings.py` to import the canonical constants from `const.py` and export them via `__all__` to preserve existing import paths. 
- Added `tools/import_check.py` which prepends the repo root to `sys.path` and attempts to import core integration modules, failing loudly on `ImportError`.

### Testing
- Ran `python3 tools/import_check.py` which failed with `No module named 'homeassistant'` due to the environment lacking the Home Assistant dependency, so the import-check cannot fully pass in this CI-like environment.
- No other automated tests could be completed here because of the missing external `homeassistant` dependency; the change set is limited to import/constant refactors and the import-check script to detect regressions when run in a complete environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696e583444f4832e96057eca1a514d87)