### PR TITLE
pumpsteer: Smooth price braking using area-based peak detection

### DIFF
--- a/tests/test_price_brake.py
+++ b/tests/test_price_brake.py
@@ -2,6 +2,8 @@ from custom_components.pumpsteer.price_brake import (
     compute_block_area,
     compute_brake_level,
     compute_price_brake,
+    detect_expensive_blocks,
+    select_price_block,
 )
 
 
@@ -67,3 +69,16 @@ def test_area_drives_amplitude():
 
     assert long_block.area > short_block.area
     assert long_amplitude > short_amplitude
+
+
+def test_selects_largest_area_block():
+    forward_prices = [1.0, 2.0, 1.0, 4.0, 4.0, 1.0]
+    threshold = 1.5
+
+    blocks = detect_expensive_blocks(
+        forward_prices, threshold, dt_minutes=60, min_block_duration_min=60
+    )
+    selected = select_price_block(blocks)
+
+    assert selected is not None
+    assert selected.start_index == 3


### PR DESCRIPTION
### Motivation
- Undvik att enstaka 15‑minutersprickar triggar kraftig bromsning genom att istället upptäcka och ranka sammanhängande dyra perioder (områden) och bromsa mjukt före och efter dessa.
- Ge en amplitud baserad på blockets area så att längre/mer kostsamma block ger starkare men proportionell bromsning.

### Description
- Lägg till block-rankning med `rank_price_blocks` och filtrering av kommande/block i gång med `filter_upcoming_blocks`, och välj block med `select_price_block` i `price_brake.py`.
- Anpassa `compute_price_brake` så att endast kommande eller pågående block beaktas och amplitud beräknas som `clamp(area / area_scale, 0..1)`.
- Implementera en mjuk rampfunktion `compute_brake_level` (smoothstep) runt blockets start och slut samt en hjälpfunktion för percentilberäkning.
- Lägg till ett enhetstest i `tests/test_price_brake.py` som verifierar att blocket med störst area väljs, samt utökning av testfall för area/amplitud och rampning.

### Testing
- Körda stil/syntaxkontroller: `flake8 custom_components/pumpsteer --select=E9,F63,F7,F82,F401` — lyckades.  
- Körda stilkontroller (warnings allowed): `flake8 custom_components/pumpsteer --ignore=E203,E501,W503,W504,E131,E122,E303,W293 --max-line-length=120 --exit-zero` — lyckades (varningar ignorerades).  
- Syntaxvalidering: `python -c "...ast.parse(...)"` över alla filer — lyckades.  
- Ruff: `ruff check` — lyckades; `ruff format --check` krävde reformat och `ruff format` kördes för att åtgärda en fil — lyckades efter formatering.  
- Pytest: `pytest tests/ -v` och `pytest tests/test_price_brake.py -v` — misslyckades i denna miljö på grund av saknade externa testberoenden (`homeassistant` och att testmiljön inte har paketvägen för `custom_components`), så enhetsfallen kördes inte här; de är skrivna och commits finns lokalt.  

Commits och ändrade filer:
- `314da50` — pumpsteer: Add area-based price block detection (ändrat `custom_components/pumpsteer/price_brake.py`).
- `cdd3784` — tests: Add unit tests for price block braking (ändrat `tests/test_price_brake.py`).

Noteringar:
- Installation av `pytest-homeassistant-custom-component` avbröts p.g.a. pip-resolver/backtracking och lokala `pytest`-körningar misslyckades därför med saknat `homeassistant` i testmiljön; dessa beroenden brukar finnas i CI för Home Assistant integrationer.
- Inga remote-push eller öppna PR på GitHub kunde utföras från denna miljö (ingen git-remote konfigurerad).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696e6a2cddec832e9a7f96f2432f7fb7)