### PR TITLE
Store options in entry.options and prefer options for defaults in options flow

### DIFF
--- a/custom_components/pumpsteer/options_flow.py
+++ b/custom_components/pumpsteer/options_flow.py
@@ -36,14 +36,9 @@ class PumpSteerOptionsFlowHandler(config_entries.OptionsFlow):
             errors = await self._validate_entities(combined_data)
 
             if not errors:
-                updated_data = entry.data.copy()
-                updated_data.update(combined_data)
+                return self.async_create_entry(title="", data=user_input)
 
-                self.hass.config_entries.async_update_entry(entry, data=updated_data)
-
-                return self.async_create_entry(title="", data={})
-
-        current_data = entry.data
+        current_data = {**entry.data, **entry.options}
 
         return self.async_show_form(
             step_id="init",


### PR DESCRIPTION
### Motivation
- Align the options flow with Home Assistant standards by storing adjustable settings in `entry.options` instead of mutating `entry.data`.

### Description
- Return `data=user_input` from `async_create_entry` in the options flow so Home Assistant saves the results into `entry.options` rather than updating `entry.data`.
- Prefer values from `entry.options` when populating form defaults and fall back to `entry.data` to preserve backward compatibility (`current_data = {**entry.data, **entry.options}`).
- Keep all validation and hardcoded-entity handling unchanged and avoid refactoring unrelated code.

### Testing
- Ran `pytest`, which failed during collection with `ModuleNotFoundError: No module named 'homeassistant'`, so unit tests could not complete in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696e837cc8e8832ebca4038a5504e7e7)