### PR TITLE
Add single-instance unique_id to PumpSteer config flow

### DIFF
--- a/custom_components/pumpsteer/config_flow.py
+++ b/custom_components/pumpsteer/config_flow.py
@@ -11,6 +11,7 @@ from .options_flow import PumpSteerOptionsFlowHandler
 _LOGGER = logging.getLogger(__name__)
 
 DOMAIN = "pumpsteer"
+UNIQUE_ID = "pumpsteer"
 
 # Hardcoded entities that are always present in the package file
 HARDCODED_ENTITIES = {
@@ -32,6 +33,9 @@ class PumpSteerConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     async def async_step_user(self, user_input=None):
         """Handle the initial step of the config flow"""
         errors = {}
+
+        await self.async_set_unique_id(UNIQUE_ID)
+        self._abort_if_unique_id_configured()
 
         if user_input is not None:
             combined_data = {**user_input, **HARDCODED_ENTITIES}


### PR DESCRIPTION
### Motivation
- Make the config flow single-instance and prevent duplicate integrations by assigning a stable unique identifier instead of inventing a device identifier.

### Description
- Add `UNIQUE_ID = "pumpsteer"` and call `await self.async_set_unique_id(UNIQUE_ID)` followed by `self._abort_if_unique_id_configured()` in `async_step_user` of `custom_components/pumpsteer/config_flow.py` so the flow aborts when an entry with the same unique id already exists.

### Testing
- Ran `pytest`, which failed during collection due to missing Home Assistant test dependency (`ModuleNotFoundError: No module named 'homeassistant'`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696e84ac7720832ea362df8b6cd99a07)