### PR TITLE
Defer PumpSteer settings validation to setup

### DIFF
--- a/custom_components/pumpsteer/__init__.py
+++ b/custom_components/pumpsteer/__init__.py
@@ -4,7 +4,9 @@ import logging
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 
+from .ml_settings import validate_ml_settings
 from .options_flow import PumpSteerOptionsFlowHandler
+from .settings import validate_core_settings
 
 _LOGGER = logging.getLogger(__name__)
 DOMAIN = "pumpsteer"
@@ -12,6 +14,16 @@ DOMAIN = "pumpsteer"
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up the PumpSteer integration"""
+    try:
+        validate_core_settings()
+        validate_ml_settings()
+    except ValueError as err:
+        _LOGGER.error(
+            "PumpSteer settings validation failed; setup aborted: %s",
+            err,
+        )
+        return False
+
     await hass.config_entries.async_forward_entry_setups(entry, ["sensor"])
 
     _LOGGER.info("PumpSteer integration setup completed")

--- a/custom_components/pumpsteer/ml_settings.py
+++ b/custom_components/pumpsteer/ml_settings.py
@@ -158,7 +158,6 @@ def get_ml_settings_info() -> dict:
     }
 
 
-validate_ml_settings()
 _LOGGER.debug(
-    "PumpSteer ML settings loaded successfully (version %s)", ML_MODULE_VERSION
+    "PumpSteer ML settings module loaded (version %s)", ML_MODULE_VERSION
 )

--- a/custom_components/pumpsteer/settings.py
+++ b/custom_components/pumpsteer/settings.py
@@ -172,12 +172,7 @@ def validate_core_settings() -> None:
         raise ValueError(error_msg)
 
 
-try:
-    validate_core_settings()
-    _LOGGER.debug(
-        "PumpSteer core settings loaded successfully (version %s)",
-        PUMPSTEER_VERSION,
-    )
-except Exception as e:
-    _LOGGER.error("Failed to load PumpSteer settings: %s", e)
-    raise
+_LOGGER.debug(
+    "PumpSteer core settings module loaded (version %s)",
+    PUMPSTEER_VERSION,
+)


### PR DESCRIPTION
### Motivation
- Prevent the integration from raising during module import by avoiding import-time validation that can raise exceptions.
- Ensure integration import remains safe in environments where Home Assistant objects are not available or settings may be adjusted at runtime.
- Validate configuration once Home Assistant is starting the integration so failures can be handled gracefully.

### Description
- Removed import-time calls to `validate_ml_settings()` and `validate_core_settings()` in `ml_settings.py` and `settings.py` so those modules no longer raise during import. 
- Kept lightweight module-load debug logging in both `ml_settings.py` and `settings.py` and left the validator functions in place for later use. 
- Added validation calls to `async_setup_entry` in `custom_components/pumpsteer/__init__.py` where `validate_core_settings()` and `validate_ml_settings()` are invoked inside a `try`/`except` block that logs a clear error and returns `False` to abort setup on validation failure.

### Testing
- Ran `pytest -q`, which failed during test collection with `ModuleNotFoundError: No module named 'homeassistant'`, so test execution did not reach integration setup validation.
- No automated tests explicitly exercised the new validation timing in this environment due to missing Home Assistant test dependencies.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696e85819c78832e99988efdaf44f672)