### PR TITLE
Run ML regression in executor to avoid blocking event loop

### DIFF
--- a/custom_components/pumpsteer/ml_adaptive.py
+++ b/custom_components/pumpsteer/ml_adaptive.py
@@ -319,8 +319,12 @@ class PumpSteerMLCollector:
         )
 
         # Trigger learning update
-        self._update_learning_model()
+        self.hass.async_create_task(self._async_update_learning_model())
         self.hass.async_create_task(self.async_save_data())
+
+    async def _async_update_learning_model(self) -> None:
+        """Run the regression update in the executor to avoid blocking."""
+        await self.hass.async_add_executor_job(self._update_learning_model)
 
     def _update_learning_model(self) -> None:
         """Perform a simple regression analysis on collected sessions"""


### PR DESCRIPTION
### Motivation
- Flytta CPU-tung ML-regression bort från Home Assistants event-loop för att förhindra att modelluppdateringar blockerar övrig asynkron IO och tidskritiska uppgifter.
- Behålla samma funktionella beteende och resultat; endast ändra i vilken exekveringskontext regressionssteget körs.

### Description
- Ersätter direktanropet `self._update_learning_model()` med en schemalagd asynk uppgift `self.hass.async_create_task(self._async_update_learning_model())` när en session avslutas.
- Lägger till `async def _async_update_learning_model(self) -> None:` som kör den tunga beräkningen via `await self.hass.async_add_executor_job(self._update_learning_model)`.
- Behåller befintlig synkrona regressionsfunktion `def _update_learning_model(self) -> None:` oförändrad så att beräkningslogiken och modellformatet inte ändras.
- Fortsätter att anropa `self.hass.async_create_task(self.async_save_data())` som tidigare så data sparas som förut.

### Testing
- Körde `pytest`, men testkörningen avbröts med fel `ModuleNotFoundError: No module named 'homeassistant'` så inga enhetstester lyckades köras i den här miljön.
- Ingen automatiserad test för ändringen kördes framgångsrikt på grund av saknade Home Assistant-bibliotek, men ändringen är en isolerad körkontext-ändring utan logiska ändringar i regressionskoden.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696e875b3694832e9d90d59f68965533)