### PR TITLE
PumpSteer: expose fake_outdoor_temperature as state rounded to 1 decimal

### DIFF
--- a/custom_components/pumpsteer/sensor/sensor.py
+++ b/custom_components/pumpsteer/sensor/sensor.py
@@ -742,7 +742,7 @@ class PumpSteerSensor(Entity):
         adjusted_temp, final_adjust = self._apply_control_bias(
             fake_temp, sensor_data, pi_data
         )
-        self._state = round(adjusted_temp, 1)
+        self._state = round(fake_temp, 1)
 
         self._attributes = self._build_attributes(
             sensor_data,


### PR DESCRIPTION
### Motivation
- Exponera PumpSteer-sensorens state som det beräknade `fake_outdoor_temperature` avrundat till en decimal så att sensorn visar t.ex. `-1.0` eller `20.9` utan att ändra någon beräkningslogik.

### Description
- I `async_update` sätts `self._state = round(fake_temp, 1)` istället för tidigare `round(adjusted_temp, 1)`, vilket endast ändrar presentation/avrundning och lämnar all annan logik oförändrad.

### Testing
- Körde `pytest` i repot; testkörningen avbröts av 5 importfel eftersom `homeassistant` saknas i testmiljön (automatiska tester kunde därför inte köras framgångsrikt).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696e8da7f4a8832eab5f7d2ac07f7ca3)