### PR TITLE
Avoid import-time manifest.json reads; store version in hass.data

### DIFF
--- a/custom_components/pumpsteer/__init__.py
+++ b/custom_components/pumpsteer/__init__.py
@@ -3,13 +3,14 @@
 import logging
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers.integration import async_get_integration
 
+from .const import DATA_VERSION, DOMAIN
 from .ml_settings import validate_ml_settings
 from .options_flow import PumpSteerOptionsFlowHandler
 from .settings import validate_core_settings
 
 _LOGGER = logging.getLogger(__name__)
-DOMAIN = "pumpsteer"
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
@@ -23,6 +24,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             err,
         )
         return False
+
+    integration = await async_get_integration(hass, DOMAIN)
+    hass.data.setdefault(DOMAIN, {})[DATA_VERSION] = integration.version
 
     await hass.config_entries.async_forward_entry_setups(entry, ["sensor"])
 

--- a/custom_components/pumpsteer/const.py
+++ b/custom_components/pumpsteer/const.py
@@ -3,6 +3,7 @@
 from typing import Final, List, Optional
 
 DOMAIN: Final[str] = "pumpsteer"
+DATA_VERSION: Final[str] = "version"
 
 PUMPSTEER_VERSION: Final[str] = "1.2.1"
 DEFAULT_HOUSE_INERTIA: Final[float] = 1.0

--- a/custom_components/pumpsteer/sensor/ml_sensor.py
+++ b/custom_components/pumpsteer/sensor/ml_sensor.py
@@ -8,13 +8,12 @@ from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 import homeassistant.util.dt as dt_util
 
+from ..const import DATA_VERSION, DOMAIN
 from ..ml_adaptive import PumpSteerMLCollector
-from ..utils import safe_float, get_state, get_version
+from ..utils import safe_float, get_state
 from ..ml_settings import ML_MIN_SESSIONS_FOR_ANALYSIS
 
 _LOGGER = logging.getLogger(__name__)
-
-SW_VERSION = get_version()
 
 # Related Home Assistant entities used for cross-reference
 ML_RELATED_ENTITIES = {
@@ -40,12 +39,13 @@ class PumpSteerMLSensor(SensorEntity):
         self._last_error: str | None = None
         self._attr_available = True
 
+        sw_version = hass.data.get(DOMAIN, {}).get(DATA_VERSION, "unknown")
         self._attr_device_info = DeviceInfo(
             identifiers={("pumpsteer", config_entry.entry_id)},
             name="PumpSteer",
             manufacturer="Custom",
             model="PumpSteer ML",
-            sw_version=SW_VERSION,
+            sw_version=sw_version,
         )
 
         self.ml = PumpSteerMLCollector(hass)

--- a/custom_components/pumpsteer/sensor/sensor.py
+++ b/custom_components/pumpsteer/sensor/sensor.py
@@ -17,6 +17,8 @@ from ..holiday import is_holiday_mode_active
 from ..temp_control_logic import calculate_temperature_output
 from ..electricity_price import async_hybrid_classify_with_history, classify_prices
 from ..const import (
+    DATA_VERSION,
+    DOMAIN,
     DEFAULT_HOUSE_INERTIA,
     HOLIDAY_TEMP,
     BRAKE_FAKE_TEMP,
@@ -51,7 +53,6 @@ from ..utils import (
     safe_float,
     get_state,
     get_attr,
-    get_version,
     should_precool,
     detect_price_interval_minutes,
     compute_price_slot_index,
@@ -69,10 +70,6 @@ try:
 except ImportError as e:
     ML_AVAILABLE = False
     _LOGGER.warning("ML features disabled: %s", e)
-
-DOMAIN = "pumpsteer"
-
-SW_VERSION = get_version()
 
 # Hardcoded entities
 HARDCODED_ENTITIES = {
@@ -137,12 +134,13 @@ class PumpSteerSensor(SensorEntity):
         self._attr_icon = "mdi:thermostat-box"
         self._attr_available = True
 
+        sw_version = hass.data.get(DOMAIN, {}).get(DATA_VERSION, "unknown")
         self._attr_device_info = DeviceInfo(
             identifiers={(DOMAIN, config_entry.entry_id)},
             name="PumpSteer",
             manufacturer="Custom",
             model="Heat Pump Controller",
-            sw_version=SW_VERSION,
+            sw_version=sw_version,
         )
 
         self.ml_collector = None

--- a/custom_components/pumpsteer/utils.py
+++ b/custom_components/pumpsteer/utils.py
@@ -1,8 +1,6 @@
-import json
 import logging
 import math
 from datetime import datetime
-from pathlib import Path
 from typing import Any, List, Optional, Tuple, Union
 from homeassistant.core import HomeAssistant
 from homeassistant.const import STATE_UNAVAILABLE, STATE_UNKNOWN
@@ -17,27 +15,6 @@ from .const import (
 )
 
 _LOGGER = logging.getLogger(__name__)
-
-
-def get_version() -> str:
-    """Load integration version from manifest.json"""
-    manifest_path = Path(__file__).resolve().parent / "manifest.json"
-    try:
-        with open(manifest_path, encoding="utf-8") as manifest_file:
-            data = json.load(manifest_file)
-    except FileNotFoundError:
-        _LOGGER.error("manifest.json not found at %s", manifest_path)
-        return "unknown"
-    except json.JSONDecodeError as err:
-        _LOGGER.error("Error decoding manifest.json: %s", err)
-        return "unknown"
-
-    version = data.get("version")
-    if not version:
-        _LOGGER.error("Version not set in manifest.json")
-        return "unknown"
-
-    return version
 
 
 def safe_float(


### PR DESCRIPTION
### Motivation
- Prevent any file I/O at module import by removing code that reads `manifest.json` during import. 
- Compute and expose the integration version once during setup to avoid repeated or blocking file access. 
- Keep sensors and device info able to report the integration version without performance or import-time side effects.

### Description
- Store the integration version in `hass.data[DOMAIN][DATA_VERSION]` during `async_setup_entry` using `async_get_integration(...).version` and added `DATA_VERSION` constant in `const.py`.
- Removed the `get_version()` manifest-reading helper from `utils.py` and eliminated module-level `SW_VERSION = get_version()` usage.
- Updated sensor modules (`sensor.py`, `ml_sensor.py`) to read `sw_version` from `hass.data` at entity construction instead of calling `get_version()` at import time.
- Adjusted imports and removed now-unused manifest-related code paths to ensure no file I/O happens during module import.

### Testing
- Ran `pytest -q`; test collection failed with `ModuleNotFoundError: No module named 'homeassistant'`, so unit tests could not be executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696e925d7840832eb3e633592a241562)