### PR TITLE
Handle config entry option reloads

### DIFF
--- a/custom_components/pumpsteer/sensor/sensor.py
+++ b/custom_components/pumpsteer/sensor/sensor.py
@@ -158,7 +158,6 @@ class PumpSteerSensor(SensorEntity):
         else:
             _LOGGER.info("PumpSteer: Running without ML features")
 
-        config_entry.add_update_listener(self.async_options_update_listener)
         _LOGGER.debug("PumpSteerSensor: Initialization complete")
 
     @property
@@ -183,11 +182,6 @@ class PumpSteerSensor(SensorEntity):
             await self.ml_collector.async_shutdown()
         self.ml_collector = None
         await super().async_will_remove_from_hass()
-
-    async def async_options_update_listener(self, entry: ConfigEntry) -> None:
-        """Handle options update event"""
-        self._config_entry = entry
-        await self.async_update()
 
     def _get_sensor_data(self, config: Dict[str, Any]) -> Dict[str, Any]:
         """Fetch sensor data from Home Assistant"""


### PR DESCRIPTION
### Motivation
- Flytta hantering av options-uppdateringar till integrationsnivå för att följa Home Assistant best practices och undvika entitetsnivå-lyssnare som kan läcka.
- Säkerställ att options-ändringar triggar en full konfigurationspost-omladdning (`async_reload`) så att plattformen uppdateras korrekt.

### Description
- Lägg till `_async_handle_options_update` i `custom_components/pumpsteer/__init__.py` som kör `await hass.config_entries.async_reload(entry.entry_id)` när options ändras.
- Registrera lyssnaren i `async_setup_entry` via `entry.add_update_listener(...)` och spara unsubscribe-callbacken i `hass.data[DOMAIN]['unsub_options_listeners'][entry.entry_id]`.
- Rensa och kör unsubscribe-callbacken i `async_unload_entry` för att undvika läckta lyssnare efter unload/reload.
- Ta bort entitetsnivå-anropet `config_entry.add_update_listener(...)` och motsvarande `async_options_update_listener` i `custom_components/pumpsteer/sensor/sensor.py`.
- Livscykelhantering: options-ändringar hanteras centralt genom en reload av hela config entry, och unsubscribe-callbacken lagras och körs vid unload för att undvika kvarstående lyssnare.

### Testing
- Körda automatiska tester: `pytest -q` kördes men misslyckades under testinsamling med `ModuleNotFoundError: No module named 'homeassistant'` på grund av saknad Home Assistant-testmiljö (ingen testsucces kunde verifieras).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696e950da170832e899aec35bc28a96f)