### PR TITLE
Flytta stora prislistor från sensor till diagnostics

### DIFF
--- a/custom_components/pumpsteer/diagnostics.py
+++ b/custom_components/pumpsteer/diagnostics.py
@@ -1,0 +1,27 @@
+"""Diagnostics support for PumpSteer."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
+
+from .const import DOMAIN
+
+
+async def async_get_config_entry_diagnostics(
+    hass: HomeAssistant, config_entry: ConfigEntry
+) -> dict[str, Any]:
+    """Return diagnostics for a PumpSteer config entry."""
+    entity_registry = er.async_get(hass)
+    entities = er.async_entries_for_config_entry(entity_registry, config_entry.entry_id)
+    domain_data = hass.data.get(DOMAIN, {})
+    diagnostics_store = domain_data.get("diagnostics", {})
+    debug_arrays = diagnostics_store.get(config_entry.entry_id, {})
+
+    return {
+        "entities": [entity.entity_id for entity in entities],
+        "debug_arrays": debug_arrays,
+    }


### PR DESCRIPTION
### Motivation
- Reducera storleken på sensorns `extra_state_attributes` genom att flytta stora, lista-liknande debug-arrayer till Home Assistant diagnostics så att huvudattributen förblir små och snabba att serialisera.
- Bevara kärnattribut och funktionalitet i sensorn oförändrade samtidigt som detaljerad felsökningsdata fortsatt är tillgänglig via diagnostics.

### Description
- Lagt till `custom_components/pumpsteer/diagnostics.py` med `async_get_config_entry_diagnostics` som exponerar lagrade debug-arrayer för en config entry.
- Sensorn skriver nu stora listor (t.ex. `price_categories_all_hours` och `next_3_hours_prices`) till en diagnostic-store i `hass.data[DOMAIN]['diagnostics'][entry_id]` istället för i `extra_state_attributes` genom nya `_update_diagnostics`.
- Tagit bort de stora listorna från sensorns attributbyggare så att `extra_state_attributes` inte längre innehåller 24/96-slot-arrayer; övriga kärn- och korta attribut är oförändrade.
- Inget ändrat i sensorernas publika beteende för normala små attribut eller i ML-sensorn; endast flytt av stora debug-arrayer för felsökning.

### Testing
- Körda automatiska tester med `pytest`, vilket avbröts på grund av ett miljöfel: `ModuleNotFoundError: No module named 'homeassistant'` (tester kunde därför inte köras framgångsrikt).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696e95f73550832e98b1163c52e27025)