### PR TITLE
Use Home Assistant Store for ML data persistence

### DIFF
--- a/custom_components/pumpsteer/ml_settings.py
+++ b/custom_components/pumpsteer/ml_settings.py
@@ -5,7 +5,9 @@ _LOGGER = logging.getLogger(__name__)
 
 ML_MODULE_VERSION: Final[str] = "1.0.0"
 
-ML_DATA_FILE_PATH: Final[str] = "/config/pumpsteer_ml_data.json"
+ML_STORAGE_KEY: Final[str] = "pumpsteer_ml_data"
+ML_STORAGE_VERSION: Final[int] = 1
+ML_LEGACY_DATA_FILENAME: Final[str] = "pumpsteer_ml_data.json"
 ML_MAX_SAVED_SESSIONS: Final[int] = 100
 ML_MAX_SESSION_UPDATES: Final[int] = 100
 ML_TRIMMED_UPDATES: Final[int] = 50
@@ -145,7 +147,8 @@ def get_ml_settings_info() -> dict:
     """Get information about current ML settings"""
     return {
         "version": ML_MODULE_VERSION,
-        "data_file": ML_DATA_FILE_PATH,
+        "storage_key": ML_STORAGE_KEY,
+        "storage_version": ML_STORAGE_VERSION,
         "min_sessions_for_analysis": ML_MIN_SESSIONS_FOR_ANALYSIS,
         "min_sessions_for_recommendations": ML_MIN_SESSIONS_FOR_RECOMMENDATIONS,
         "min_sessions_for_autotune": ML_MIN_SESSIONS_FOR_AUTOTUNE,


### PR DESCRIPTION
### Motivation
- Replace the hardcoded file-based ML persistence with Home Assistant's `Store` API to avoid relying on `/config` paths and to integrate with HA storage abstractions.
- Preserve existing ML schema and version fields while keeping business logic, model calculations, and session collection behavior unchanged.
- Provide a one-time import path from the legacy file so existing user data is preserved without deleting the old file.

### Description
- Introduced `ML_STORAGE_KEY`, `ML_STORAGE_VERSION`, and `ML_LEGACY_DATA_FILENAME` in `ml_settings.py` and replaced the old file path constant with storage metadata.
- Reworked `PumpSteerMLCollector` in `ml_adaptive.py` to use `homeassistant.helpers.storage.Store` for async load/save and to store the `Store` instance on initialization.
- Implemented a legacy-import flow that tries to read the old legacy file once via `hass.config.path(...)` (executed in the executor), imports it into the `Store`, and then continues using the `Store` without deleting the legacy file.
- Kept version-mismatch handling robust and non-blocking by performing migrations and writing migrated defaults back to `Store` asynchronously, and ensured the collector uses `_apply_loaded_data` to populate in-memory fields.
- Did not change any ML algorithm, session collection, summaries, or persisted data schema fields.

### Testing
- Ran `pytest`, which aborted during collection with `ModuleNotFoundError: No module named 'homeassistant'`, so unit tests could not be executed in this environment.
- Verified locally (code inspection and lint) that no hardcoded `/config/...` path remains and that `Store` async methods are used for load/save, and that the legacy import is attempted only if `Store` is empty.

Migration note: on startup the collector first attempts to load data from the HA `Store`; if no `Store` data exists it attempts to import the legacy `pumpsteer_ml_data.json` via `hass.config.path(...)` once, logs the import, saves the imported payload into `Store`, and continues using `Store` going forward while leaving the legacy file in place.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696e98139c7c832eacb6fbab56634180)