### PR TITLE
Enable extreme price brake override and normalize temperature deficit handling

### DIFF
--- a/custom_components/pumpsteer/const.py
+++ b/custom_components/pumpsteer/const.py
@@ -51,6 +51,8 @@ PRICE_BLOCK_THRESHOLD_PERCENTILE: Final[Optional[float]] = None
 PRICE_BRAKE_PRE_MINUTES: Final[int] = 60
 PRICE_BRAKE_POST_MINUTES: Final[int] = 60
 PRICE_BLOCK_AREA_SCALE: Final[float] = 4.0
+EXTREME_PRICE_BRAKE_OVERRIDE_PERCENTILE: Final[float] = 0.95
+EXTREME_PRICE_MAX_DEFICIT_ALLOW_BRAKE_C: Final[float] = 1.0
 
 COMFORT_PI_KP: Final[float] = 0.6
 COMFORT_PI_KI: Final[float] = 0.1
@@ -65,7 +67,7 @@ CONTROL_BIAS_TEMP_SCALE: Final[float] = 1.5
 # Defines when the system considers the indoor temperature "too cold"
 # to allow price braking. Previously hardcoded as -0.5 °C inside the logic.
 #
-# If indoor_temp - target_temp < HEATING_THRESHOLD:
+# If target_temp - indoor_temp > abs(HEATING_THRESHOLD):
 #     → PumpSteer enters heating mode regardless of price.
 #
 # Increasing the value to -1.0 or -1.5 allows more price braking

--- a/tests/test_temperature_vs_price.py
+++ b/tests/test_temperature_vs_price.py
@@ -221,3 +221,28 @@ def test_price_categories_do_not_force_braking():
 
         assert mode == "neutral"
         assert fake_temp == data["outdoor_temp"]
+
+
+def test_extreme_price_override_brakes_with_small_deficit():
+    s = create_sensor()
+    data = base_sensor_data(indoor_temp=20.48, target_temp=21.0)
+    prices = [4.39, 2.27, 2.27, 2.27]
+    pi_data = s._compute_controls(
+        data,
+        prices,
+        0,
+        60,
+        {},
+        prices,
+        4.39,
+        "very_expensive (percentiles)",
+    )
+    fake_temp, mode = s._calculate_output_temperature(
+        data,
+        "very_expensive (percentiles)",
+        0,
+        price_brake_level=pi_data["price_brake_level"],
+        brake_blocked_reason=pi_data["brake_blocked_reason"],
+    )
+    assert "brake" in mode
+    assert pi_data["price_brake_level"] > 0


### PR DESCRIPTION
### Motivation
- Fix a bug where `very_expensive`/`extreme` price categories did not trigger price braking when the house was slightly below target due to inconsistent temperature sign conventions and strict gating.
- Allow an explicit override so extreme price events can force braking unless the indoor deficit exceeds a safe limit.

### Description
- Add two new constants in `const.py`: `EXTREME_PRICE_BRAKE_OVERRIDE_PERCENTILE` and `EXTREME_PRICE_MAX_DEFICIT_ALLOW_BRAKE_C` to configure extreme-price override behavior.
- Canonicalize temperature deficit handling by introducing `temp_deficit_c = target_temp - indoor_temp` in `temp_control_logic.py` and use that consistently for heating/braking decisions.
- Update `sensor._compute_controls` to compute `price_factor`, evaluate `is_extreme_price`, apply the override to `desired_brake_level` when allowed, and expose a diagnostic field `brake_blocked_reason` with values like `none`, `too_cold`, `no_price_data`, `rate_limited`, `not_expensive`, or `other`.
- Propagate `price_brake_level` and `brake_blocked_reason` into `_calculate_output_temperature` and switch neutral mode to `braking_by_price` when braking is applied.
- Add a unit test `test_extreme_price_override_brakes_with_small_deficit` to `tests/test_temperature_vs_price.py` that exercises the extreme-price override scenario.

### Testing
- Ran `pytest tests/test_temperature_vs_price.py`, which raised a collection error (`ModuleNotFoundError: No module named 'custom_components'`) in this environment preventing full test execution. 
- Verified the modified modules import/readable locally via static inspection and committed the changes successfully.
- Manual code inspection confirms the new constants, the canonical `temp_deficit_c` usage, the override logic that raises `price_brake_level > 0` for extreme prices up to the configured deficit, and the added `brake_blocked_reason` diagnostic field.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696f29d1cbf8832eb1999be16b169aa7)