### PR TITLE
Enable expensive-now braking outside price blocks

### DIFF
--- a/tests/test_block_window.py
+++ b/tests/test_block_window.py
@@ -1,10 +1,12 @@
 from datetime import datetime, timedelta
 
+from homeassistant.util import dt as dt_util
+
 from custom_components.pumpsteer.price_brake import PriceBlock
 from custom_components.pumpsteer.sensor.sensor import compute_block_window
 
 
-def test_compute_block_window_active_now():
+def test_compute_block_window_active_now(monkeypatch):
     update_time = datetime(2024, 1, 1, 12, 0, 0)
     block = PriceBlock(
         start_index=0,
@@ -13,6 +15,10 @@ def test_compute_block_window_active_now():
         area=1.5,
         peak=2.5,
     )
+    if hasattr(dt_util, "utcnow"):
+        monkeypatch.setattr(dt_util, "utcnow", lambda: dt_util.as_utc(update_time))
+    else:
+        monkeypatch.setattr(dt_util, "now", lambda: update_time)
 
     block_start, block_end, in_price_block, block_state = compute_block_window(
         update_time, block


### PR DESCRIPTION
### Motivation
- Add a lightweight "expensive-now" braking trigger so the system can apply a minimum brake level during immediately expensive prices even when not inside a detected price block.
- Fix a timing reference in block detection so block windows are computed against the actual current UTC time.

### Description
- Implemented `expensive_now` logic inside `_compute_controls` that triggers when the `price_category` is `very_expensive`/`extreme` or when `expensive` and `current_price > threshold`, and computes a small minimum `desired_brake_level` scaled by `aggressiveness` and a `price_factor` derived from the combined price series.
- Updated `brake_blocked_reason` handling so `no_price_block` is only set when not in a block and `expensive_now` is false, and preserved existing `too_cold` and rate-limiting behavior.
- Changed `compute_block_window` to compare block start/end against the current UTC time using `dt_util.utcnow()` with a fallback to `dt_util.now()` for compatibility.
- Extended `_compute_controls` signature to accept `current_price` and `price_category` and updated callers accordingly.
- Added unit tests: `test_expensive_now_braking_outside_block` to validate the new expensive-now behavior, and updated `test_compute_block_window_active_now` to monkeypatch `dt_util` for deterministic time-based testing.

### Testing
- Ran `pytest tests/test_block_window.py` and the test passed (1 passed).
- Ran `pytest tests/test_temperature_vs_price.py` and the suite passed including the new `test_expensive_now_braking_outside_block` (14 passed).
- Both test runs succeeded after adjustments to `compute_block_window` and the added logic in `_compute_controls`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696f4376fce8832e9793dabb3ae4fc09)