### PR TITLE
Support multi-block price brake lookahead

### DIFF
--- a/custom_components/pumpsteer/const.py
+++ b/custom_components/pumpsteer/const.py
@@ -51,6 +51,7 @@ PRICE_BLOCK_THRESHOLD_PERCENTILE: Final[Optional[float]] = None
 PRICE_BRAKE_PRE_MINUTES: Final[int] = 60
 PRICE_BRAKE_POST_MINUTES: Final[int] = 60
 PRICE_BLOCK_AREA_SCALE: Final[float] = 4.0
+LOOKAHEAD_HOURS: Final[int] = 12
 
 COMFORT_PI_KP: Final[float] = 0.6
 COMFORT_PI_KI: Final[float] = 0.1


### PR DESCRIPTION
### Motivation
- Allow the price-brake logic to detect and consider up to two expensive price blocks within a forward (rolling) lookahead window so morning+evening peaks can be handled without forcing blocks on calm days.
- Limit analysis to a bounded forward horizon to avoid using distant day-two prices for immediate braking decisions.
- Preserve backward compatibility for existing attributes such as `block_detected` and `next_block_start`/`next_block_end` while exposing richer block metadata.

### Description
- Add a new `LOOKAHEAD_HOURS` constant (default 12) and use it in `build_forward_price_series` calls so forward price series are limited to the lookahead window (`const.py`, `sensor/sensor.py`).
- Implement `select_price_blocks()` and helper `blocks_overlap()` to pick up to two non-overlapping expensive `PriceBlock` instances ranked by area, and return them sorted by start time (`price_brake.py`).
- Change `compute_price_brake()` to return both a primary `block` (the active block or nearest upcoming block used for brake amplitude/level) and a `blocks` list; primary block selection favors an upcoming block and falls back to an active block when no upcoming block exists (`price_brake.py`).
- Add `compute_block_status()` to produce block windows, determine `active_block_index`, `in_price_block`, `block_state`, and provide `block_windows` for the sensor; update sensor logic to use the new status and expose attributes `blocks_detected`, `block_1_*`, `block_2_*`, `active_block_index`, and `price_blocks` while keeping `block_detected`, `next_block_start`, `next_block_end`, and `duration_minutes` (where `duration_minutes` is derived from the nearest upcoming block, or the active block if no upcoming block exists) (`sensor/sensor.py`).

### Testing
- Ran a lightweight module import test via `importlib.util` and executed a simulation of `detect_expensive_blocks` + `select_price_blocks`, which returned two blocks for a two-peak price series and zero blocks for a flat series (succeeded).
- Attempted a direct `python` invocation that imports the package top-level but it failed due to a missing `homeassistant` dependency in the environment (expected in this isolated test environment).
- Project changes were committed after verifying the select/detect logic with the simulated price lists described above (commit: "Add multi-block lookahead for price brake").

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696f55b5040c832ea12bb5c4416be57e)