### PR TITLE
Apply braking relative to active/next price block and expose metadata

### DIFF
--- a/custom_components/pumpsteer/sensor/sensor.py
+++ b/custom_components/pumpsteer/sensor/sensor.py
@@ -342,6 +342,7 @@ class PumpSteerSensor(SensorEntity):
             area_scale=PRICE_BLOCK_AREA_SCALE,
             now_offset_minutes=0.0,
         )
+        next_block = price_brake.get("next_block")
 
         (
             block_start,
@@ -370,7 +371,16 @@ class PumpSteerSensor(SensorEntity):
                 desired_brake_level, base_min + 0.20 * scale
             )
             brake_blocked_reason = "expensive_now"
-        if desired_brake_level <= 0.0 and not in_price_block and not expensive_now:
+        pre_window_active = False
+        if next_block is not None:
+            pre_start = next_block.start_offset_minutes - PRICE_BRAKE_PRE_MINUTES
+            pre_window_active = pre_start <= 0 < next_block.start_offset_minutes
+        if (
+            desired_brake_level <= 0.0
+            and not in_price_block
+            and not expensive_now
+            and not pre_window_active
+        ):
             brake_blocked_reason = "no_price_block"
         if too_cold_to_brake:
             desired_brake_level = 0.0


### PR DESCRIPTION
### Motivation
- Ensure braking is calculated against the correct block when multiple blocks exist by using the active block when now is inside a block and ramping toward the nearest upcoming block otherwise.
- Prevent `brake_blocked_reason` from incorrectly reporting `no_price_block` when we are in a pre-brake ramp for a next block.

### Description
- Add `resolve_active_and_next_blocks` to determine `active_block` and `next_block` from a block or list of blocks and return a canonical block list.
- Use `resolve_active_and_next_blocks` inside `compute_price_brake` to pick the `primary_block` (`active_block` or `next_block`) and expose `active_block` and `next_block` in the returned metadata while ensuring `blocks` includes them for status reporting.
- Update sensor control flow to read `price_brake["next_block"]` and detect the pre-brake window so `brake_blocked_reason` is not set to `no_price_block` during pre-brake ramping.
- Leave rate limiting behavior intact (no changes to `apply_rate_limit`).

### Testing
- Ran `pytest`, which failed during collection with an `ImportError: cannot import name 'compute_block_window' from custom_components.pumpsteer.sensor.sensor'`, causing the test run to fail.
- No further automated tests were executed after the change due to the collection error.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696f579bf9d0832e8c44e6e5e4f02659)