### PR TITLE
Persist winter price brake offset and apply to control temperature

### DIFF
--- a/tests/ha_test_stubs.py
+++ b/tests/ha_test_stubs.py
@@ -35,6 +35,7 @@ core.HomeAssistant = HomeAssistant
 sys.modules["homeassistant.core"] = core
 
 helpers = types.ModuleType("homeassistant.helpers")
+helpers.__path__ = []
 sys.modules["homeassistant.helpers"] = helpers
 
 entity = types.ModuleType("homeassistant.helpers.entity")
@@ -77,6 +78,23 @@ class AddEntitiesCallback:
 
 entity_platform.AddEntitiesCallback = AddEntitiesCallback
 sys.modules["homeassistant.helpers.entity_platform"] = entity_platform
+
+storage_mod = types.ModuleType("homeassistant.helpers.storage")
+
+
+class Store:
+    def __init__(self, hass, version, key):
+        self._data = None
+
+    async def async_load(self):
+        return self._data
+
+    async def async_save(self, data):
+        self._data = data
+
+
+storage_mod.Store = Store
+sys.modules["homeassistant.helpers.storage"] = storage_mod
 
 selector_mod = types.ModuleType("homeassistant.helpers.selector")
 


### PR DESCRIPTION
### Motivation
- Allow a real, persistent winter price braking offset to affect the computed control temperature so expensive prices actually raise the control signal. 
- Compute brake targets from price pressure and apply them only when outdoor temperature is below `WINTER_BRAKE_THRESHOLD` using the existing `WINTER_BRAKE_TEMP_OFFSET`. 
- Surface the braking internals as attributes so users can inspect `brake_target_c`, `brake_offset_c`, and `control_outdoor_temperature` at runtime.

### Description
- Add a per-entry `Store` (`_brake_offset_store`) and persistence helpers `async_load`/`async_save` wrappers via `_load_brake_offset` and `_persist_brake_offset` to hold `brake_offset_c` across restarts. 
- Compute `price_pressure = clamp(price_factor_percent / 100, 0, 1)` and `brake_target_c = price_pressure * WINTER_BRAKE_TEMP_OFFSET` (applied only when `sensor_data["outdoor_temp"] <= WINTER_BRAKE_THRESHOLD`), then rate-limit the applied `brake_offset_c` using the existing `apply_rate_limit`. 
- Apply the offset to the temperature used for control as `control_outdoor_temperature = fake_temp + brake_offset_c` and clamp that final control temperature within `MIN_FAKE_TEMP..MAX_FAKE_TEMP` before passing it into `_apply_control_bias`. 
- Ensure attributes `brake_target_c`, `brake_offset_c`, and `control_outdoor_temperature` are populated in the sensor attributes for visibility. 
- Guard ML initialization for test environments and add a minimal `Store` stub in test helpers so unit tests can run without a full Home Assistant runtime.

Note: the implementation uses only the existing constants `WINTER_BRAKE_TEMP_OFFSET`, `WINTER_BRAKE_THRESHOLD`, `MIN_FAKE_TEMP`, and `MAX_FAKE_TEMP` as requested.

### Testing
- Ran `pytest` against the repository test suite; final result: `31 passed`. 
- During development initial test collection failed due to missing `homeassistant.helpers.storage` in the test stubs, which was resolved by adding a minimal `Store` stub; after that all tests passed.

Explanation of the true control signal: the effective control value sent to the heat pump is the PI-adjusted temperature `adjusted_temp` which is assigned to the sensor via `self._attr_native_value` after `control_outdoor_temperature` (which includes `brake_offset_c`) is run through `_apply_control_bias`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696faa742d08832ebd83b20707de1e5d)