### PR TITLE
Skala vinter‑bromsmål baserat på block_state

### DIFF
--- a/custom_components/pumpsteer/sensor/sensor.py
+++ b/custom_components/pumpsteer/sensor/sensor.py
@@ -980,8 +980,17 @@ class PumpSteerSensor(SensorEntity):
             mode = "braking_by_price"
         price_pressure = max(0.0, min(price_factor_percent / 100.0, 1.0))
         is_winter = sensor_data["outdoor_temp"] <= WINTER_BRAKE_THRESHOLD
+        block_state = pi_data.get("block_state", "none")
+        block_scale = 0.0
+        if block_state == "active":
+            block_scale = 1.0
+        elif block_state == "upcoming":
+            block_scale = 0.5
+        # Apply block-based scaling to the winter brake target.
         target_brake_offset_c = (
-            price_pressure * WINTER_BRAKE_TEMP_OFFSET if is_winter else 0.0
+            price_pressure * WINTER_BRAKE_TEMP_OFFSET * block_scale
+            if is_winter
+            else 0.0
         )
         previous_brake_offset = (
             self._last_brake_offset if self._last_brake_offset is not None else 0.0


### PR DESCRIPTION
### Motivation
- Införa block‑beroende skalning av vinterbromsmålet så att bromsning ges full styrka under ett aktivt prisblock, reducerad styrka för kommande block och noll efter block.
- Behålla befintlig rampnings/logik för att säkerställa mjuka förändringar och att offset kan rampas ner till noll.

### Description
- Hämtar `block_state` från `pi_data` och mappar det till en `block_scale` där `active` => `1.0`, `upcoming` => `0.5` och `none` => `0.0`.
- Multiplicerar `price_pressure * WINTER_BRAKE_TEMP_OFFSET` med `block_scale` när `is_winter` och lagrar det i `target_brake_offset_c` i `custom_components/pumpsteer/sensor/sensor.py`.
- Lämnar befintlig rate‑limiting och rampningskod (`apply_rate_limit` och `_last_brake_offset`) oförändrad så att målvärdet fortfarande rampas upp/ner.

### Testing
- Körde `pytest` mot projektet och alla automatiska tester kördes framgångsrikt (31 passed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696fb230eb94832e95fc534fb6452924)