### PR TITLE
Clean up PumpSteer sensor attributes and expand diagnostics

### DIFF
--- a/custom_components/pumpsteer/diagnostics.py
+++ b/custom_components/pumpsteer/diagnostics.py
@@ -5,10 +5,30 @@ from __future__ import annotations
 from typing import Any
 
 from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import (
+    CONF_ACCESS_TOKEN,
+    CONF_API_KEY,
+    CONF_CLIENT_ID,
+    CONF_CLIENT_SECRET,
+    CONF_PASSWORD,
+    CONF_TOKEN,
+    CONF_USERNAME,
+)
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
+from homeassistant.helpers.redact import redact_data
 
 from .const import DOMAIN
+
+TO_REDACT = {
+    CONF_ACCESS_TOKEN,
+    CONF_API_KEY,
+    CONF_CLIENT_ID,
+    CONF_CLIENT_SECRET,
+    CONF_PASSWORD,
+    CONF_TOKEN,
+    CONF_USERNAME,
+}
 
 
 async def async_get_config_entry_diagnostics(
@@ -22,6 +42,7 @@ async def async_get_config_entry_diagnostics(
     debug_arrays = diagnostics_store.get(config_entry.entry_id, {})
 
     return {
+        "config_entry": redact_data(config_entry.as_dict(), TO_REDACT),
         "entities": [entity.entity_id for entity in entities],
-        "debug_arrays": debug_arrays,
+        "internal_state": debug_arrays,
     }

--- a/tests/test_const.py
+++ b/tests/test_const.py
@@ -1,5 +1,4 @@
 import sys
-from datetime import datetime
 from pathlib import Path
 
 sys.path.append(str(Path(__file__).resolve().parents[1]))
@@ -31,12 +30,10 @@ def test_build_attributes_basic():
         "summer_threshold": 15.0,
         "outdoor_temp_forecast_entity": True,
     }
-    prices = [1.2, 1.5, 1.1, 1.3]
     current_price = 1.2
     price_category = "normal"
     mode = "heating"
     holiday = False
-    categories = ["normal", "high", "low"]
     now_hour = 1
 
     s = sensor.PumpSteerSensor(DummyHass(), DummyConfigEntry())
@@ -62,20 +59,17 @@ def test_build_attributes_basic():
         "brake_blocked_reason": "no_price_block",
     }
 
+    decision_reason = s._get_decision_reason(mode, price_category)
     attrs = s._build_attributes(
         sensor_data,
-        prices,
         current_price,
         price_category,
         mode,
         holiday,
-        categories,
-        now_hour,
         price_interval_minutes=60,
-        current_slot_index=0,
         pi_data=pi_data,
-        final_adjust=0.0,
-        update_time=datetime(2024, 1, 1, now_hour, 0, 0),
+        decision_reason=decision_reason,
+        brake_offset_c=0.0,
     )
     assert attrs["mode"] == "heating"
     assert attrs["current_price"] == 1.2
@@ -93,12 +87,10 @@ def test_decision_reason_very_cheap_heating():
         "summer_threshold": 15.0,
         "outdoor_temp_forecast_entity": True,
     }
-    prices = [0.5, 0.6]
     current_price = 0.5
     price_category = "very_cheap"
     mode = "heating"
     holiday = False
-    categories = ["very_cheap", "cheap"]
     now_hour = 0
 
     s = sensor.PumpSteerSensor(DummyHass(), DummyConfigEntry())
@@ -124,20 +116,17 @@ def test_decision_reason_very_cheap_heating():
         "brake_blocked_reason": "no_price_block",
     }
 
+    decision_reason = s._get_decision_reason(mode, price_category)
     attrs = s._build_attributes(
         sensor_data,
-        prices,
         current_price,
         price_category,
         mode,
         holiday,
-        categories,
-        now_hour,
         price_interval_minutes=60,
-        current_slot_index=0,
         pi_data=pi_data,
-        final_adjust=0.0,
-        update_time=datetime(2024, 1, 1, now_hour, 0, 0),
+        decision_reason=decision_reason,
+        brake_offset_c=0.0,
     )
     assert attrs["decision_reason"] == "heating - Triggered by very cheap price"
 
@@ -152,12 +141,10 @@ def test_decision_reason_precool():
         "summer_threshold": 15.0,
         "outdoor_temp_forecast_entity": True,
     }
-    prices = [1.0, 1.2]
     current_price = 1.0
     price_category = "normal"
     mode = "precool"
     holiday = False
-    categories = ["normal", "high"]
     now_hour = 0
 
     s = sensor.PumpSteerSensor(DummyHass(), DummyConfigEntry())
@@ -183,19 +170,16 @@ def test_decision_reason_precool():
         "brake_blocked_reason": "no_price_block",
     }
 
+    decision_reason = s._get_decision_reason(mode, price_category)
     attrs = s._build_attributes(
         sensor_data,
-        prices,
         current_price,
         price_category,
         mode,
         holiday,
-        categories,
-        now_hour,
         price_interval_minutes=60,
-        current_slot_index=0,
         pi_data=pi_data,
-        final_adjust=0.0,
-        update_time=datetime(2024, 1, 1, now_hour, 0, 0),
+        decision_reason=decision_reason,
+        brake_offset_c=0.0,
     )
     assert attrs["decision_reason"] == "precool - Triggered by pre-cool (warm forecast)"


### PR DESCRIPTION
### Motivation
- Rensa upp `sensor.pumpsteer` så att UI visar endast användarvänliga fält och inte interna kontroll-/pris-/PI-variabler, samtidigt som full intern status görs tillgänglig via diagnostics för felsökning.
- Flytta interna data ur UI-attributen för bättre läsbarhet och för att undvika att exponera stora debug-arrayer eller potentiellt känslig information.

### Description
- Begränsar attributen som `sensor.pumpsteer` exponerar genom att förenkla `_build_attributes` i `custom_components/pumpsteer/sensor/sensor.py` så att endast användarorienterade fält finns kvar (t.ex. `mode`, `status`, `decision_reason`, `current_price`, `price_category`, `price_interval_minutes`, `target_temperature`, `indoor_temperature`, `outdoor_temperature`, `aggressiveness`, `inertia`, `holiday_mode`, `forecast_available`, `block_state`, `in_price_block`, `brake_offset_c`).
- Samlar och serialiserar alla interna värden (block-, ramp-, price- och PI-interna) i en diagnostics-payload i `async_update` och skickar denna vidare till diagnostics-samlingen istället för att lägga dem i UI-attribut.
- Lagt till hjälpfunktioner `._get_decision_reason`, `._serialize_block` och `._serialize_block_window` för tydlig formatering av beslutstext och blockdata för diagnostics.
- Uppdaterar `custom_components/pumpsteer/diagnostics.py` för att returnera `internal_state` och att redigera konfidentiella fält i config entry med `redact_data` (`CONF_ACCESS_TOKEN`, `CONF_API_KEY`, `CONF_CLIENT_ID`, `CONF_CLIENT_SECRET`, `CONF_PASSWORD`, `CONF_TOKEN`, `CONF_USERNAME`).
- Anpassat tester i `tests/test_const.py` för den nya attributsignaturen och hjälpfunktionerna.

### Testing
- Körde `pytest` lokalt mot projektet; alla tester kördes och avslutade utan fel.
- Resultat: `pytest` — 31 passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696fb2e84cd0832e98a8b747c09f9548)