### PR TITLE
Harden price parsing and ML persistence without numpy

### DIFF
--- a/custom_components/pumpsteer/electricity_price.py
+++ b/custom_components/pumpsteer/electricity_price.py
@@ -2,7 +2,7 @@ import logging
 from datetime import datetime, timedelta
 from typing import Dict, List
 
-import numpy as np
+import statistics
 from homeassistant.components.recorder import get_instance
 from homeassistant.components.recorder.history import get_significant_states
 from homeassistant.core import HomeAssistant
@@ -63,6 +63,34 @@ def validate_price_list(
     return True
 
 
+def _percentile(values: List[float], percentile: float) -> float:
+    """
+    Compute the percentile using linear interpolation between closest ranks.
+    """
+    if not values:
+        return 0.0
+
+    sorted_values = sorted(values)
+    if len(sorted_values) == 1:
+        return float(sorted_values[0])
+
+    if percentile <= 0:
+        return float(sorted_values[0])
+    if percentile >= 100:
+        return float(sorted_values[-1])
+
+    k = (len(sorted_values) - 1) * (percentile / 100)
+    lower_index = int(k)
+    upper_index = min(lower_index + 1, len(sorted_values) - 1)
+    lower_value = sorted_values[lower_index]
+    upper_value = sorted_values[upper_index]
+    if lower_index == upper_index:
+        return float(lower_value)
+
+    weight = k - lower_index
+    return float(lower_value + (upper_value - lower_value) * weight)
+
+
 def classify_prices(
     price_list: List[float], percentiles: List[float] = None
 ) -> List[str]:
@@ -85,31 +113,28 @@ def classify_prices(
     if len(percentiles) != 4:
         raise ValueError("Exactly 4 percentiles required for 5-category classification")
 
-    price_array = np.array(price_list)
+    positive_prices = [price for price in price_list if price >= 0]
 
-    positive_prices = price_array[price_array >= 0]
-
-    if len(positive_prices) > 0:
-        thresholds = np.percentile(positive_prices, percentiles)
+    if positive_prices:
+        thresholds = [
+            _percentile(positive_prices, percentile) for percentile in percentiles
+        ]
     else:
         # If all prices are negative, all are classified as 'negative_price'
         return ["negative_price"] * len(price_list)
 
-    categories_positive = np.select(
-        [
-            positive_prices < thresholds[0],
-            positive_prices < thresholds[1],
-            positive_prices < thresholds[2],
-            positive_prices < thresholds[3],
-        ],
-        [
-            "very_cheap",
-            "cheap",
-            "normal",
-            "expensive",
-        ],
-        default="very_expensive",
-    )
+    categories_positive = []
+    for price in positive_prices:
+        if price < thresholds[0]:
+            categories_positive.append("very_cheap")
+        elif price < thresholds[1]:
+            categories_positive.append("cheap")
+        elif price < thresholds[2]:
+            categories_positive.append("normal")
+        elif price < thresholds[3]:
+            categories_positive.append("expensive")
+        else:
+            categories_positive.append("very_expensive")
 
     final_categories = []
     positive_index = 0
@@ -179,24 +204,34 @@ async def async_hybrid_classify_with_history(
     end_time = dt_now()
     start_time = end_time - timedelta(hours=trailing_hours)
 
-    recorder = get_instance(hass)
+    try:
+        recorder = get_instance(hass)
 
-    def get_price_history():
-        return get_significant_states(hass, start_time, end_time, [price_entity_id])
+        def get_price_history():
+            return get_significant_states(
+                hass, start_time, end_time, [price_entity_id]
+            )
 
-    history = await recorder.async_add_executor_job(get_price_history)
+        history = await recorder.async_add_executor_job(get_price_history)
 
-    states = history.get(price_entity_id, [])
-    trailing_prices = []
+        states = history.get(price_entity_id, [])
+        trailing_prices = []
 
-    # Process historical states to extract valid numeric prices
-    for s in states:
-        try:
-            if s.state not in ("unknown", "unavailable"):
-                trailing_prices.append(float(s.state))
-        except (ValueError, TypeError):
-            _LOGGER.debug("Skipping invalid state value from history: %s", s.state)
-            continue
+        # Process historical states to extract valid numeric prices
+        for s in states:
+            try:
+                if s.state not in ("unknown", "unavailable"):
+                    trailing_prices.append(float(s.state))
+            except (ValueError, TypeError):
+                _LOGGER.debug("Skipping invalid state value from history: %s", s.state)
+                continue
+    except Exception as err:
+        _LOGGER.warning(
+            "Failed to retrieve history for %s; falling back to percentile classification: %s",
+            price_entity_id,
+            err,
+        )
+        return classify_prices(price_list)
 
     # Calculate the average price from the retrieved historical data
     if not trailing_prices:
@@ -256,11 +291,11 @@ def get_price_statistics(price_list: List[float]) -> Dict[str, float]:
         }
 
     return {
-        "average": round(np.mean(positive_prices), 3),
-        "median": round(np.median(positive_prices), 3),
+        "average": round(statistics.mean(positive_prices), 3),
+        "median": round(statistics.median(positive_prices), 3),
         "min": round(min(price_list), 3),  # Keep original min, as it can be negative
         "max": round(max(price_list), 3),
-        "std": round(np.std(positive_prices), 3),
+        "std": round(statistics.pstdev(positive_prices), 3),
     }
 
 

--- a/custom_components/pumpsteer/holiday.py
+++ b/custom_components/pumpsteer/holiday.py
@@ -2,7 +2,7 @@ from datetime import datetime
 import logging
 from homeassistant.core import HomeAssistant
 from homeassistant.util.dt import parse_datetime
-from homeassistant.const import STATE_ON
+from homeassistant.const import STATE_ON, STATE_UNAVAILABLE, STATE_UNKNOWN
 from .settings import HOLIDAY_TEMP
 
 _LOGGER = logging.getLogger(__name__)
@@ -67,10 +67,29 @@ def is_holiday_mode_active(
         )
         return False
 
+    if holiday_start_state.state in (
+        STATE_UNKNOWN,
+        STATE_UNAVAILABLE,
+        "",
+        None,
+    ) or holiday_end_state.state in (
+        STATE_UNKNOWN,
+        STATE_UNAVAILABLE,
+        "",
+        None,
+    ):
+        _LOGGER.warning(
+            "[PumpSteer - Holiday] Holiday datetime states are invalid. "
+            "Start state: '%s', End state: '%s'",
+            holiday_start_state.state,
+            holiday_end_state.state,
+        )
+        return False
+
     try:
         holiday_start_time = parse_datetime(holiday_start_state.state)
         holiday_end_time = parse_datetime(holiday_end_state.state)
-    except ValueError as e:
+    except (ValueError, TypeError) as e:
         _LOGGER.warning(
             "[PumpSteer - Holiday] Error parsing holiday datetime states. "
             "Start state: '%s', End state: '%s', Error: %s",
@@ -80,8 +99,6 @@ def is_holiday_mode_active(
         )
         return False
 
-    current_time = datetime.now(holiday_start_time.tzinfo)
-
     if holiday_start_time is None or holiday_end_time is None:
         _LOGGER.warning(
             "[PumpSteer - Holiday] Could not parse holiday datetime states. "
@@ -90,6 +107,8 @@ def is_holiday_mode_active(
             holiday_end_state.state,
         )
         return False
+
+    current_time = datetime.now(holiday_start_time.tzinfo)
 
     if holiday_start_time <= current_time <= holiday_end_time:
         _LOGGER.debug(

--- a/custom_components/pumpsteer/ml_adaptive.py
+++ b/custom_components/pumpsteer/ml_adaptive.py
@@ -11,7 +11,6 @@ from typing import Dict, Any, Optional, List
 import json
 import logging
 import statistics
-import numpy as np
 
 
 from homeassistant.core import HomeAssistant
@@ -31,6 +30,65 @@ from .ml_settings import (
 )
 
 _LOGGER = logging.getLogger(__name__)
+
+
+def _reset_learning_state(collector: "PumpSteerMLCollector") -> None:
+    collector.learning_sessions = []
+    collector.learning_summary = {}
+    collector.model_coefficients = None
+
+
+def _least_squares_coefficients(
+    x_values: List[List[float]], y_values: List[float]
+) -> List[float]:
+    if not x_values or not y_values or len(x_values) != len(y_values):
+        return []
+
+    features = []
+    for row in x_values:
+        if len(row) != 3:
+            return []
+        features.append([row[0], row[1], row[2], 1.0])
+
+    size = 4
+    xtx = [[0.0 for _ in range(size)] for _ in range(size)]
+    xty = [0.0 for _ in range(size)]
+
+    for feature_row, y_value in zip(features, y_values):
+        for i in range(size):
+            xty[i] += feature_row[i] * y_value
+            for j in range(size):
+                xtx[i][j] += feature_row[i] * feature_row[j]
+
+    solution = _solve_linear_system(xtx, xty)
+    return solution or []
+
+
+def _solve_linear_system(
+    matrix: List[List[float]], vector: List[float]
+) -> Optional[List[float]]:
+    size = len(vector)
+    augmented = [row[:] + [vector[i]] for i, row in enumerate(matrix)]
+
+    for col in range(size):
+        pivot_row = max(range(col, size), key=lambda r: abs(augmented[r][col]))
+        if abs(augmented[pivot_row][col]) < 1e-12:
+            return None
+        if pivot_row != col:
+            augmented[col], augmented[pivot_row] = augmented[pivot_row], augmented[col]
+
+        pivot = augmented[col][col]
+        for j in range(col, size + 1):
+            augmented[col][j] /= pivot
+
+        for row in range(size):
+            if row == col:
+                continue
+            factor = augmented[row][col]
+            for j in range(col, size + 1):
+                augmented[row][j] -= factor * augmented[col][j]
+
+    return [augmented[i][size] for i in range(size)]
 
 
 class PumpSteerMLCollector:
@@ -67,8 +125,18 @@ class PumpSteerMLCollector:
             _LOGGER.debug("ML: No previous data found.")
             return
 
-        with open(self.data_file, "r", encoding="utf-8") as f:
-            data = json.load(f)
+        try:
+            with open(self.data_file, "r", encoding="utf-8") as f:
+                data = json.load(f)
+        except json.JSONDecodeError as err:
+            _LOGGER.error("ML: Failed to decode JSON data: %s", err)
+            self._handle_corrupt_data_file()
+            self._reset_learning_data()
+            return
+        except OSError as err:
+            _LOGGER.error("ML: Failed to read data file: %s", err)
+            self._reset_learning_data()
+            return
 
         self.learning_sessions = data.get("sessions", [])
         self.learning_summary = data.get("learning_summary", {})
@@ -81,6 +149,21 @@ class PumpSteerMLCollector:
                 file_version,
                 ML_DATA_VERSION,
             )
+
+    def _handle_corrupt_data_file(self) -> None:
+        corrupt_path = Path(f"{self.data_file}.corrupt")
+        try:
+            Path(self.data_file).rename(corrupt_path)
+            _LOGGER.warning(
+                "ML: Renamed corrupt data file to %s", corrupt_path
+            )
+        except OSError as err:
+            _LOGGER.warning(
+                "ML: Failed to rename corrupt data file: %s", err
+            )
+
+    def _reset_learning_data(self) -> None:
+        _reset_learning_state(self)
 
     async def async_save_data(self) -> None:
         await self.hass.async_add_executor_job(self._save_data_sync)
@@ -96,9 +179,12 @@ class PumpSteerMLCollector:
             "model_coefficients": self.model_coefficients,
         }
 
-        Path(self.data_file).parent.mkdir(parents=True, exist_ok=True)
-        with open(self.data_file, "w", encoding="utf-8") as f:
-            json.dump(data, f, indent=2)
+        try:
+            Path(self.data_file).parent.mkdir(parents=True, exist_ok=True)
+            with open(self.data_file, "w", encoding="utf-8") as f:
+                json.dump(data, f, indent=2)
+        except OSError as err:
+            _LOGGER.error("ML: Failed to save learning data: %s", err)
 
     def start_session(self, initial_data: Dict[str, Any]) -> None:
         """Start a new learning session"""
@@ -297,9 +383,12 @@ class PumpSteerMLCollector:
             x.append([aggr, inertia, dur])
             y.append(drift)
 
-        a = np.column_stack((np.array(x), np.ones(len(x))))
-        coeff, *_ = np.linalg.lstsq(a, np.array(y), rcond=None)
-        self.model_coefficients = coeff.tolist()
+        coeff = _least_squares_coefficients(x, y)
+        if not coeff:
+            _LOGGER.warning("ML: Regression failed; skipping coefficient update.")
+            return
+
+        self.model_coefficients = coeff
 
         self.learning_summary = {
             "total_sessions": len(valid_summaries),

--- a/custom_components/pumpsteer/sensor/ml_sensor.py
+++ b/custom_components/pumpsteer/sensor/ml_sensor.py
@@ -145,7 +145,8 @@ class PumpSteerMLSensor(Entity):
 
     def _determine_state(self, insights: Dict[str, Any]) -> str:
         """Decide what the main state string should be"""
-        summary = insights.get("summary", {}) or {}
+        summary = insights.get("summary", {})
+        summary = summary if isinstance(summary, dict) else {}
         total = summary.get("total_sessions", 0) or 0
         coeffs = summary.get("coefficients")
 
@@ -165,17 +166,19 @@ class PumpSteerMLSensor(Entity):
     ) -> Dict[str, Any]:
         """Build a clear and concise attribute dictionary"""
         summary = insights.get("summary", {})
+        summary = summary if isinstance(summary, dict) else {}
+        summary_stats = summary.get("summary", {}) if isinstance(summary, dict) else {}
         recs = insights.get("recommendations", [])
 
         attributes = {
             "total_sessions": summary.get("total_sessions"),
-            "avg_duration": summary.get("avg_duration"),
-            "avg_drift": summary.get("avg_drift"),
-            "avg_inertia": summary.get("avg_inertia"),
-            "avg_aggressiveness": summary.get("avg_aggressiveness"),
+            "avg_duration": summary_stats.get("avg_duration"),
+            "avg_drift": summary_stats.get("avg_drift"),
+            "avg_inertia": summary_stats.get("avg_inertia"),
+            "avg_aggressiveness": summary_stats.get("avg_aggressiveness"),
             "coefficients": summary.get("coefficients"),
             "recommendations": recs or ["Collecting data…"],
-            "last_learning_update": summary.get("updated"),
+            "last_learning_update": summary_stats.get("updated"),
             # control system info
             "auto_tune_active": control_data.get("autotune_active"),
             "inertia": control_data.get("inertia"),

--- a/custom_components/pumpsteer/sensor/sensor.py
+++ b/custom_components/pumpsteer/sensor/sensor.py
@@ -1,4 +1,5 @@
 import logging
+import math
 from datetime import datetime
 from typing import Optional, Dict, Any, Tuple, List
 
@@ -404,15 +405,37 @@ class PumpSteerSensor(Entity):
             _LOGGER.warning("Could not retrieve electricity prices from %s", entity_id)
             return [], 0.0, "unknown", [], 60, 0
 
-        try:
-            prices = [
-                float(p)
-                for p in prices_raw
-                if isinstance(p, (float, int)) and p is not None
-            ]
-        except (ValueError, TypeError) as e:
-            _LOGGER.error("Error converting prices to float: %s", e)
-            return [], 0.0, "unknown", [], 60, 0
+        def extract_price_value(item: Any) -> Optional[float]:
+            if item is None:
+                return None
+
+            if isinstance(item, dict):
+                if "value" in item:
+                    return extract_price_value(item.get("value"))
+                if "price" in item:
+                    return extract_price_value(item.get("price"))
+                return None
+
+            if isinstance(item, (float, int)):
+                return float(item)
+
+            if isinstance(item, str):
+                stripped = item.strip()
+                if not stripped or stripped.lower() in ("unknown", "unavailable"):
+                    return None
+                try:
+                    return float(stripped)
+                except ValueError:
+                    return None
+
+            return None
+
+        prices = []
+        for item in prices_raw:
+            value = extract_price_value(item)
+            if value is None or not math.isfinite(value):
+                continue
+            prices.append(value)
 
         if not prices:
             _LOGGER.warning("No valid prices found after conversion")
@@ -544,67 +567,75 @@ class PumpSteerSensor(Entity):
 
     async def async_update(self) -> None:
         """Update sensor data"""
+        try:
+            update_time = dt_util.now()
+            now_hour = update_time.hour
 
-        update_time = dt_util.now()
-        now_hour = update_time.hour
+            config = {**self._config_entry.data, **self._config_entry.options}
+            sensor_data = self._get_sensor_data(config)
+            (
+                prices,
+                current_price,
+                price_category,
+                categories,
+                price_interval_minutes,
+                current_slot_index,
+            ) = await self._get_price_data(config, update_time)
+            self._last_current_price = current_price
+            self._last_price_category = price_category
 
-        config = {**self._config_entry.data, **self._config_entry.options}
-        sensor_data = self._get_sensor_data(config)
-        (
-            prices,
-            current_price,
-            price_category,
-            categories,
-            price_interval_minutes,
-            current_slot_index,
-        ) = await self._get_price_data(config, update_time)
-        self._last_current_price = current_price
-        self._last_price_category = price_category
+            missing = self._validate_required_data(sensor_data, prices)
+            if missing:
+                self._state = STATE_UNAVAILABLE
+                self._attributes = {
+                    "Status": f"Missing: {', '.join(missing)}",
+                    "Last Updated": update_time.isoformat(),
+                    "Current Hour": now_hour,
+                }
+                return
 
-        missing = self._validate_required_data(sensor_data, prices)
-        if missing:
+            holiday = is_holiday_mode_active(
+                self.hass,
+                HARDCODED_ENTITIES["holiday_mode_boolean_entity"],
+                HARDCODED_ENTITIES["holiday_start_datetime_entity"],
+                HARDCODED_ENTITIES["holiday_end_datetime_entity"],
+            )
+
+            if holiday:
+                sensor_data["target_temp"] = HOLIDAY_TEMP
+
+            fake_temp, mode = self._calculate_output_temperature(
+                sensor_data,
+                price_category,
+                current_slot_index,
+            )
+            self._state = round(fake_temp, 1)
+
+            self._attributes = self._build_attributes(
+                sensor_data,
+                prices,
+                current_price,
+                price_category,
+                mode,
+                holiday,
+                categories,
+                now_hour,
+                price_interval_minutes,
+                current_slot_index,
+            )
+
+            if self.ml_collector:
+                self._collect_ml_data(sensor_data, mode, fake_temp)
+
+            self._last_update_time = update_time
+        except Exception as err:
+            _LOGGER.exception("PumpSteer sensor update failed: %s", err)
             self._state = STATE_UNAVAILABLE
             self._attributes = {
-                "Status": f"Missing: {', '.join(missing)}",
-                "Last Updated": update_time.isoformat(),
-                "Current Hour": now_hour,
+                "status": "error",
+                "last_error": str(err),
+                "last_updated": dt_util.now().isoformat(),
             }
-            return
-
-        holiday = is_holiday_mode_active(
-            self.hass,
-            HARDCODED_ENTITIES["holiday_mode_boolean_entity"],
-            HARDCODED_ENTITIES["holiday_start_datetime_entity"],
-            HARDCODED_ENTITIES["holiday_end_datetime_entity"],
-        )
-
-        if holiday:
-            sensor_data["target_temp"] = HOLIDAY_TEMP
-
-        fake_temp, mode = self._calculate_output_temperature(
-            sensor_data,
-            price_category,
-            current_slot_index,
-        )
-        self._state = round(fake_temp, 1)
-
-        self._attributes = self._build_attributes(
-            sensor_data,
-            prices,
-            current_price,
-            price_category,
-            mode,
-            holiday,
-            categories,
-            now_hour,
-            price_interval_minutes,
-            current_slot_index,
-        )
-
-        if self.ml_collector:
-            self._collect_ml_data(sensor_data, mode, fake_temp)
-
-        self._last_update_time = update_time
 
 
 async def async_setup_entry(


### PR DESCRIPTION
### Motivation
- Reduce dependency risk by removing `numpy` and make percentile/statistics calculations pure-Python so the integration remains installable in Home Assistant environments.
- Prevent crashes from malformed input, corrupted ML files or recorder/history failures by hardening parsing, I/O and history fetch paths.
- Ensure ML sensor reads the correct nested summary fields so attributes are populated when data exists.

### Description
- Removed `numpy` usage and added `_percentile` and pure-Python least-squares helpers, replaced `np` statistics with `statistics` and a custom linear solver in `custom_components/pumpsteer/electricity_price.py` and `custom_components/pumpsteer/ml_adaptive.py` to compute percentiles, summary stats and regression coefficients without external deps.
- Hardened price parsing in `custom_components/pumpsteer/sensor/sensor.py` to accept floats/ints, numeric strings, dicts with `value`/`price` (including nested), and to ignore `None`, empty, `unknown`, `unavailable`, `NaN` and infinities without failing the whole list.
- Guarded recorder/history fetching in `electricity_price.async_hybrid_classify_with_history` with try/except to log and fall back to percentile classification on errors, and made holiday parsing (`custom_components/pumpsteer/holiday.py`) resilient to `parse_datetime` returning `None` or to unknown/unavailable states.
- Made ML persistence robust in `custom_components/pumpsteer/ml_adaptive.py` by catching `json.JSONDecodeError` and `OSError` on load/save, renaming corrupt files to `<name>.corrupt` when JSON decoding fails, resetting to safe defaults, and avoiding exceptions during save.
- Fixed ML sensor attribute nesting in `custom_components/pumpsteer/sensor/ml_sensor.py` so `avg_*` and `last_learning_update` read from the inner `summary` object when present, and added a top-level try/except “airbag” in the main sensor update cycle to avoid entity crashes and surface `last_error`.
- Modified files: `electricity_price.py`, `sensor/sensor.py`, `holiday.py`, `ml_adaptive.py`, `sensor/ml_sensor.py`; no new config entities or external requirements added, `manifest.json` unchanged.

### Testing
- Ran unit test suite with `pytest -q`, resulting in all tests passing: `22 passed`.
- Static sanity checks (imports/types) run during development and no new unused imports remain.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697b78e56a00832e978ae3a68fe1fac6)