### PR TITLE
Lägg till passiv JSONL-telemetrilogg för PumpSteer

### DIFF
--- a/custom_components/pumpsteer/pump_log.py
+++ b/custom_components/pumpsteer/pump_log.py
@@ -4,38 +4,68 @@ from __future__ import annotations
 
 import logging
 import os
+import json
+from datetime import datetime
+from logging.handlers import RotatingFileHandler
 from typing import Any, Optional
 
 from .settings import PUMP_LOG_ENABLED
 
 _PUMP_LOG_PATH = "/config/pump.log"
 _MAX_BYTES = 1_000_000
+_TELEMETRY_DIR = "/config/pumpsteer"
+_TELEMETRY_PATH = f"{_TELEMETRY_DIR}/telemetry.jsonl"
+_TELEMETRY_MAX_BYTES = 5 * 1024 * 1024
+_TELEMETRY_BACKUP_COUNT = 3
 
 _file_logger = logging.getLogger("pumpsteer.pump_log")
 _file_logger.propagate = False
+_telemetry_logger = logging.getLogger("pumpsteer.telemetry")
+_telemetry_logger.propagate = False
 
 
 def setup_pump_log() -> None:
     """Initiera fil-handler. Ska anropas via executor, inte från event loop."""
-    if _file_logger.handlers:
+    if _file_logger.handlers and _telemetry_logger.handlers:
         return
     try:
-        if (
-            os.path.exists(_PUMP_LOG_PATH)
-            and os.path.getsize(_PUMP_LOG_PATH) > _MAX_BYTES
-        ):
-            rotated = _PUMP_LOG_PATH + ".1"
-            if os.path.exists(rotated):
-                os.remove(rotated)
-            os.rename(_PUMP_LOG_PATH, rotated)
-        handler = logging.FileHandler(_PUMP_LOG_PATH, encoding="utf-8")
-        handler.setFormatter(
-            logging.Formatter("%(asctime)s  %(message)s", datefmt="%Y-%m-%d %H:%M:%S")
-        )
-        _file_logger.addHandler(handler)
-        _file_logger.setLevel(logging.DEBUG)
+        if not _file_logger.handlers:
+            if (
+                os.path.exists(_PUMP_LOG_PATH)
+                and os.path.getsize(_PUMP_LOG_PATH) > _MAX_BYTES
+            ):
+                rotated = _PUMP_LOG_PATH + ".1"
+                if os.path.exists(rotated):
+                    os.remove(rotated)
+                os.rename(_PUMP_LOG_PATH, rotated)
+            handler = logging.FileHandler(_PUMP_LOG_PATH, encoding="utf-8")
+            handler.setFormatter(
+                logging.Formatter(
+                    "%(asctime)s  %(message)s",
+                    datefmt="%Y-%m-%d %H:%M:%S",
+                )
+            )
+            _file_logger.addHandler(handler)
+            _file_logger.setLevel(logging.DEBUG)
+
+        if not _telemetry_logger.handlers:
+            os.makedirs(_TELEMETRY_DIR, exist_ok=True)
+            telemetry_handler = RotatingFileHandler(
+                _TELEMETRY_PATH,
+                maxBytes=_TELEMETRY_MAX_BYTES,
+                backupCount=_TELEMETRY_BACKUP_COUNT,
+                encoding="utf-8",
+            )
+            telemetry_handler.setFormatter(logging.Formatter("%(message)s"))
+            _telemetry_logger.addHandler(telemetry_handler)
+            _telemetry_logger.setLevel(logging.INFO)
     except OSError:
         pass
+
+
+def _json_default(value: Any) -> str:
+    """Convert non-JSON values to strings."""
+    return str(value)
 
 
 def log_mode_change(
@@ -88,3 +118,25 @@ def log_event(msg: str, **kwargs: Any) -> None:
         _file_logger.info(f"{msg}  |  {kv}")
     else:
         _file_logger.info(msg)
+
+
+def log_telemetry_snapshot(**data: Any) -> None:
+    """Write one structured telemetry snapshot for later analysis."""
+    if not PUMP_LOG_ENABLED:
+        return
+    if not _telemetry_logger.handlers:
+        return
+
+    payload = dict(data)
+    payload.setdefault("timestamp", datetime.now().astimezone().isoformat())
+    try:
+        _telemetry_logger.info(
+            json.dumps(
+                payload,
+                ensure_ascii=False,
+                sort_keys=True,
+                default=_json_default,
+            )
+        )
+    except Exception:
+        return

--- a/custom_components/pumpsteer/sensor.py
+++ b/custom_components/pumpsteer/sensor.py
@@ -24,7 +24,7 @@ from .electricity_price import (
 )
 from .holiday import async_update_holiday
 from .ohmigo import async_push_ohmigo
-from .pump_log import log_event, log_mode_change
+from .pump_log import log_event, log_mode_change, log_telemetry_snapshot
 from .settings import (
     BRAKE_DELTA_C,
     BRAKE_HOLD_MINUTES,
@@ -1529,6 +1529,36 @@ class PumpSteerSensor(RestoreEntity):
             "last_updated": now.isoformat(),
             **extra,
         }
+        telemetry_data = {
+            "mode": mode,
+            "fake_outdoor_temperature": self._state,
+            "indoor_temperature": self._attributes.get("indoor_temperature"),
+            "target_temperature": self._attributes.get("target_temperature"),
+            "outdoor_temperature": self._attributes.get("outdoor_temperature"),
+            "price_category": self._attributes.get("price_category"),
+            "price_current": self._attributes.get("price_current"),
+            "p30": self._attributes.get("p30"),
+            "p80": self._attributes.get("p80"),
+            "aggressiveness": self._attributes.get("aggressiveness"),
+            "heating_demand_c": self._attributes.get("heating_demand_c"),
+            "pi_error_c": self._attributes.get("pi_error_c"),
+            "pi_p_term": self._attributes.get("pi_p_term"),
+            "pi_i_term": self._attributes.get("pi_i_term"),
+            "brake_factor": self._attributes.get("brake_factor"),
+            "brake_active": self._attributes.get("brake_active"),
+            "ramp_in_minutes": self._attributes.get("ramp_in_minutes"),
+            "ramp_out_minutes": self._attributes.get("ramp_out_minutes"),
+            "comfort_floor_c": self._attributes.get("comfort_floor_c"),
+            "preheat_enabled": self._attributes.get("preheat_enabled"),
+            "preheat_factor": self._attributes.get("preheat_factor"),
+            "preheat_boost_c": self._attributes.get("preheat_boost_c"),
+            "thermal_k": self._attributes.get("thermal_k"),
+            "thermal_k_valid": self._attributes.get("thermal_k_valid"),
+            "thermal_k_samples": self._attributes.get("thermal_k_samples"),
+            "status": self._attributes.get("status"),
+            "timestamp": now.isoformat(),
+        }
+        log_telemetry_snapshot(**telemetry_data)
 
         self._ohmigo_last_push = await async_push_ohmigo(
             self.hass,


### PR DESCRIPTION
### Motivation
- Inför en separat, strukturerad telemetry-logg för framtida analys av termiskt beteende utan att påverka befintlig mänsklig loggning eller kontrolllogik.
- Behåll befintliga `log_event()` och `log_mode_change()` samt den lokala, robusta och enkla arkitekturen (ingen cloud/ML/automatisk parameterändring och endast passiv datainsamling).

### Description
- Uppdaterade `custom_components/pumpsteer/pump_log.py` för att lägga till en separat telemetry-logger (`pumpsteer.telemetry`) som skriver JSON Lines till ` /config/pumpsteer/telemetry.jsonl` med `RotatingFileHandler` konfigurerad till `maxBytes=5*1024*1024` och `backupCount=3`, och som skapar katalogen ` /config/pumpsteer` vid behov.
- Implementerade `log_telemetry_snapshot(**data: Any) -> None` som respekterar `PUMP_LOG_ENABLED`, no-op:ar tyst om loggern inte initierats, injicerar en ISO-tidsstämpel om saknas, serialiserar med `json.dumps(..., ensure_ascii=False, sort_keys=True, default=_json_default)` och fångar undantag så att den aldrig kraschar kontroll-loopen.
- Lade till hjälpfunktionen `_json_default(value: Any) -> str` i `pump_log.py` för säker fallback-serialisering av icke-JSON-värden.
- Uppdaterade `custom_components/pumpsteer/sensor.py` för att importera `log_telemetry_snapshot` och anropa den en gång per lyckad `_do_update()`-cykel i `_set_state()` efter att `mode`, `fake_outdoor_temperature` och `self._attributes` har byggts, vilket ger ett enda snapshot per cykel utan att ändra någon styrningslogik.
- Telemetry-payloaden innehåller de begärda fälten när de finns (annars `None`) och loggningen är passiv och isolerad från kontrollen.

### Testing
- Körning av `python -m compileall custom_components/pumpsteer` lyckades utan kompileringsfel.
- Försökt köra en lokal runtime-smoke-check för att initiera loggers och skriva testposter misslyckades p.g.a. saknad `homeassistant`-modul i den här miljön (`ModuleNotFoundError: No module named 'homeassistant'`), så filskapande/rotation kunde inte valideras i denna miljö.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb04ba80b4832e9a299cad2a1214ef)