### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/hacs_validator.yml
+++ b/.github/workflows/hacs_validator.yml
@@ -5,6 +5,9 @@ on:
   pull_request:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   validate:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/JohanAlvedal/PumpSteer/security/code-scanning/3](https://github.com/JohanAlvedal/PumpSteer/security/code-scanning/3)

Add an explicit `permissions` block to the workflow so `GITHUB_TOKEN` is constrained to least privilege.  
Best fix here: define it at the workflow root (applies to all jobs unless overridden), with `contents: read`, which is sufficient for `actions/checkout` and typical validation actions that only read repository data.

Change required in `.github/workflows/hacs_validator.yml`:
- Insert a top-level `permissions:` section between `on:` and `jobs:`.
- Set:
  - `contents: read`

No imports, methods, or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
