### PR TITLE
Save runtime logs to <config>/pumplog and avoid writes above 10°C

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install pytest pytest-asyncio pylint homeassistant pytest-homeassistant-custom-component
+          pip install "pytest<9" pytest-asyncio pylint homeassistant pytest-homeassistant-custom-component
 
       - name: Install ruff
         uses: astral-sh/ruff-action@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install "pytest<9" pytest-asyncio pylint homeassistant pytest-homeassistant-custom-component
+          pip install "pytest<9" "pytest-asyncio<1.3" "pycares<5" pylint homeassistant pytest-homeassistant-custom-component
 
       - name: Install ruff
         uses: astral-sh/ruff-action@v3

--- a/README.md
+++ b/README.md
@@ -50,3 +50,9 @@ You use this integration at your own risk. Heating is a critical system in your 
 - 🐞 [Report a Bug / Feature Request](https://github.com/JohanAlvedal/PumpSteer/issues)
 - 📝 License: AGPL-3.0
 - © Johan Älvedal
+
+## Runtime logs
+
+PumpSteer stores local runtime logs in `<config>/pumplog/`.
+
+The files `pump.log` and `telemetry.json` are only written when the outdoor temperature is `10°C` or lower. This avoids unnecessary disk writes during warmer periods when heat-pump steering is normally not relevant.

--- a/custom_components/pumpsteer/pump_log.py
+++ b/custom_components/pumpsteer/pump_log.py
@@ -1,34 +1,86 @@
-"""Structured file logger for PumpSteer — writes to /config/pump.log."""
+"""Structured runtime file logging for PumpSteer."""
 
 from __future__ import annotations
 
+import json
 import logging
-import os
+from pathlib import Path
 from typing import Any, Optional
 
 from .settings import PUMP_LOG_ENABLED
 
-_PUMP_LOG_PATH = "/config/pump.log"
+LOG_DIR_NAME = "pumplog"
+PUMP_LOG_FILE = "pump.log"
+TELEMETRY_FILE = "telemetry.json"
+LOGGING_OUTDOOR_TEMP_THRESHOLD_C = 10.0
 _MAX_BYTES = 1_000_000
+
+_runtime_log_dir = Path("/config") / LOG_DIR_NAME
+_pump_log_path = _runtime_log_dir / PUMP_LOG_FILE
+_telemetry_path = _runtime_log_dir / TELEMETRY_FILE
 
 _file_logger = logging.getLogger("pumpsteer.pump_log")
 _file_logger.propagate = False
 
 
-def setup_pump_log() -> None:
-    """Initiera fil-handler. Ska anropas via executor, inte från event loop."""
-    if _file_logger.handlers:
-        return
+def _coerce_outdoor_temp(outdoor_temp: Any) -> Optional[float]:
+    """Return outdoor temperature as float, or None when it cannot be trusted."""
+    if outdoor_temp is None:
+        return None
+    if isinstance(outdoor_temp, str):
+        stripped = outdoor_temp.strip().lower()
+        if stripped in {"", "unknown", "unavailable", "none"}:
+            return None
+        outdoor_temp = stripped
     try:
-        if (
-            os.path.exists(_PUMP_LOG_PATH)
-            and os.path.getsize(_PUMP_LOG_PATH) > _MAX_BYTES
-        ):
-            rotated = _PUMP_LOG_PATH + ".1"
-            if os.path.exists(rotated):
-                os.remove(rotated)
-            os.rename(_PUMP_LOG_PATH, rotated)
-        handler = logging.FileHandler(_PUMP_LOG_PATH, encoding="utf-8")
+        return float(outdoor_temp)
+    except (TypeError, ValueError):
+        return None
+
+
+def _should_write_runtime_logs(outdoor_temp: Any) -> bool:
+    """Return True when runtime logs are useful enough to write."""
+    parsed_outdoor_temp = _coerce_outdoor_temp(outdoor_temp)
+    if parsed_outdoor_temp is None:
+        # Missing or invalid outdoor temperature means heating relevance cannot be
+        # assessed safely, so skip disk writes to avoid unnecessary I/O.
+        return False
+    return parsed_outdoor_temp <= LOGGING_OUTDOOR_TEMP_THRESHOLD_C
+
+
+def _resolve_log_dir(hass: Any | None = None) -> Path:
+    """Resolve the Home Assistant writable runtime log directory."""
+    if hass is not None and hasattr(hass, "config") and hasattr(hass.config, "path"):
+        return Path(hass.config.path(LOG_DIR_NAME))
+    return Path("/config") / LOG_DIR_NAME
+
+
+def setup_pump_log(hass: Any | None = None) -> None:
+    """Initialize the file handler. Should be called via executor, not the event loop."""
+    global _runtime_log_dir, _pump_log_path, _telemetry_path
+
+    _runtime_log_dir = _resolve_log_dir(hass)
+    _pump_log_path = _runtime_log_dir / PUMP_LOG_FILE
+    _telemetry_path = _runtime_log_dir / TELEMETRY_FILE
+    _runtime_log_dir.mkdir(parents=True, exist_ok=True)
+
+    if _file_logger.handlers:
+        for handler in _file_logger.handlers:
+            if (
+                isinstance(handler, logging.FileHandler)
+                and Path(handler.baseFilename) == _pump_log_path
+            ):
+                return
+            handler.close()
+        _file_logger.handlers.clear()
+
+    try:
+        if _pump_log_path.exists() and _pump_log_path.stat().st_size > _MAX_BYTES:
+            rotated = _pump_log_path.with_name(f"{PUMP_LOG_FILE}.1")
+            if rotated.exists():
+                rotated.unlink()
+            _pump_log_path.rename(rotated)
+        handler = logging.FileHandler(_pump_log_path, encoding="utf-8")
         handler.setFormatter(
             logging.Formatter("%(asctime)s  %(message)s", datefmt="%Y-%m-%d %H:%M:%S")
         )
@@ -56,6 +108,8 @@ def log_mode_change(
         return
     if old_mode == new_mode:
         return
+    if not _should_write_runtime_logs(outdoor):
+        return
     if not _file_logger.handlers:
         return
     parts = [f"MODE {old_mode or '?'} → {new_mode}", f"fake={fake_temp:.1f}°C"]
@@ -81,6 +135,9 @@ def log_mode_change(
 def log_event(msg: str, **kwargs: Any) -> None:
     if not PUMP_LOG_ENABLED:
         return
+    outdoor = kwargs.get("outdoor", kwargs.get("outdoor_temperature"))
+    if not _should_write_runtime_logs(outdoor):
+        return
     if not _file_logger.handlers:
         return
     if kwargs:
@@ -88,3 +145,18 @@ def log_event(msg: str, **kwargs: Any) -> None:
         _file_logger.info(f"{msg}  |  {kv}")
     else:
         _file_logger.info(msg)
+
+
+def write_telemetry(data: dict[str, Any], outdoor_temp: Any) -> None:
+    """Write the latest runtime telemetry snapshot when heating control is relevant."""
+    if not _should_write_runtime_logs(outdoor_temp):
+        return
+    try:
+        _runtime_log_dir.mkdir(parents=True, exist_ok=True)
+        with _telemetry_path.open("w", encoding="utf-8") as telemetry_file:
+            json.dump(
+                data, telemetry_file, ensure_ascii=False, indent=2, sort_keys=True
+            )
+            telemetry_file.write("\n")
+    except OSError:
+        pass

--- a/custom_components/pumpsteer/pump_log.py
+++ b/custom_components/pumpsteer/pump_log.py
@@ -56,7 +56,7 @@ def _resolve_log_dir(hass: Any | None = None) -> Path:
 
 
 def setup_pump_log(hass: Any | None = None) -> None:
-    """Initialize the file handler. Should be called via executor, not the event loop."""
+    """Resolve runtime log paths. Should be called via executor, not the event loop."""
     global _runtime_log_dir, _pump_log_path, _telemetry_path
 
     _runtime_log_dir = _resolve_log_dir(hass)
@@ -64,17 +64,27 @@ def setup_pump_log(hass: Any | None = None) -> None:
     _telemetry_path = _runtime_log_dir / TELEMETRY_FILE
     _runtime_log_dir.mkdir(parents=True, exist_ok=True)
 
-    if _file_logger.handlers:
-        for handler in _file_logger.handlers:
-            if (
-                isinstance(handler, logging.FileHandler)
-                and Path(handler.baseFilename) == _pump_log_path
-            ):
-                return
-            handler.close()
-        _file_logger.handlers.clear()
+    for handler in list(_file_logger.handlers):
+        if (
+            isinstance(handler, logging.FileHandler)
+            and Path(handler.baseFilename) == _pump_log_path
+        ):
+            continue
+        handler.close()
+        _file_logger.removeHandler(handler)
+
+
+def _ensure_pump_log_handler() -> bool:
+    """Create the pump log file handler only when a log line will be written."""
+    for handler in _file_logger.handlers:
+        if (
+            isinstance(handler, logging.FileHandler)
+            and Path(handler.baseFilename) == _pump_log_path
+        ):
+            return True
 
     try:
+        _runtime_log_dir.mkdir(parents=True, exist_ok=True)
         if _pump_log_path.exists() and _pump_log_path.stat().st_size > _MAX_BYTES:
             rotated = _pump_log_path.with_name(f"{PUMP_LOG_FILE}.1")
             if rotated.exists():
@@ -86,8 +96,9 @@ def setup_pump_log(hass: Any | None = None) -> None:
         )
         _file_logger.addHandler(handler)
         _file_logger.setLevel(logging.DEBUG)
+        return True
     except OSError:
-        pass
+        return False
 
 
 def log_mode_change(
@@ -110,7 +121,7 @@ def log_mode_change(
         return
     if not _should_write_runtime_logs(outdoor):
         return
-    if not _file_logger.handlers:
+    if not _ensure_pump_log_handler():
         return
     parts = [f"MODE {old_mode or '?'} → {new_mode}", f"fake={fake_temp:.1f}°C"]
     if indoor is not None:
@@ -138,7 +149,7 @@ def log_event(msg: str, **kwargs: Any) -> None:
     outdoor = kwargs.get("outdoor", kwargs.get("outdoor_temperature"))
     if not _should_write_runtime_logs(outdoor):
         return
-    if not _file_logger.handlers:
+    if not _ensure_pump_log_handler():
         return
     if kwargs:
         kv = "  ".join(f"{k}={v}" for k, v in kwargs.items())

--- a/custom_components/pumpsteer/sensor.py
+++ b/custom_components/pumpsteer/sensor.py
@@ -24,7 +24,7 @@ from .electricity_price import (
 )
 from .holiday import async_update_holiday
 from .ohmigo import async_push_ohmigo
-from .pump_log import log_event, log_mode_change
+from .pump_log import log_event, log_mode_change, write_telemetry
 from .settings import (
     BRAKE_DELTA_C,
     BRAKE_HOLD_MINUTES,
@@ -667,7 +667,7 @@ class PumpSteerSensor(RestoreEntity):
                 reason,
             )
             self._safe_mode_warned = True
-            log_event("SAFE_MODE_ENTER", reason=reason)
+            log_event("SAFE_MODE_ENTER", reason=reason, outdoor=outdoor)
         else:
             _LOGGER.debug("PumpSteer safe mode still active: %s", reason)
 
@@ -1011,6 +1011,7 @@ class PumpSteerSensor(RestoreEntity):
                     "COMFORT_FLOOR_RELEASE",
                     indoor=round(indoor, 1),
                     floor=round(comfort_floor, 1),
+                    outdoor=round(outdoor, 1),
                 )
                 brake_requested = False
                 brake_hold = 0.0
@@ -1215,7 +1216,11 @@ class PumpSteerSensor(RestoreEntity):
         )
         bridge_short_dip = upcoming and not forecast_cold and self._brake_ramp > 0.0
         if bridge_short_dip:
-            log_event("BRIDGE_SHORT_DIP", brake_factor=round(self._brake_ramp, 3))
+            log_event(
+                "BRIDGE_SHORT_DIP",
+                brake_factor=round(self._brake_ramp, 3),
+                outdoor=round(outdoor, 1),
+            )
 
         # 6. Normal PI control.
         # If the brake is still ramping out (for example after an expensive period
@@ -1505,7 +1510,11 @@ class PumpSteerSensor(RestoreEntity):
                 "PumpSteer exited SAFE MODE and returned to normal control (mode=%s)",
                 mode,
             )
-            log_event("SAFE_MODE_EXIT", new_mode=mode)
+            log_event(
+                "SAFE_MODE_EXIT",
+                new_mode=mode,
+                outdoor=extra.get("outdoor_temperature"),
+            )
             self._safe_mode_warned = False
         self._state = round(fake_temp, 1)
         log_mode_change(
@@ -1529,6 +1538,7 @@ class PumpSteerSensor(RestoreEntity):
             "last_updated": now.isoformat(),
             **extra,
         }
+        write_telemetry(self._attributes, extra.get("outdoor_temperature"))
 
         self._ohmigo_last_push = await async_push_ohmigo(
             self.hass,
@@ -1636,7 +1646,7 @@ async def async_setup_entry(
 ) -> None:
     from .pump_log import setup_pump_log
 
-    await hass.async_add_executor_job(setup_pump_log)
+    await hass.async_add_executor_job(setup_pump_log, hass)
     sensor = PumpSteerSensor(hass, config_entry)
     outlook_sensor = ThermalOutlookSensor(hass, config_entry)
     async_add_entities([sensor, outlook_sensor], update_before_add=False)

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,6 +10,12 @@ All notable changes are documented here.
 Versions follow [Semantic Versioning](https://semver.org/).
 
 ---
+## Unreleased
+
+### Changed
+- Runtime file logs now use `<config>/pumplog/` instead of a PumpSteer-named runtime folder.
+- `pump.log` and `telemetry.json` are written only when outdoor temperature is `10°C` or lower to reduce unnecessary disk I/O during warmer periods.
+
 ## [2.1.1] — Release hardening & beta output support
 
 ### Fixed

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -232,6 +232,8 @@ In **Developer Tools → Template**, you can inspect PumpSteer state directly:
 
 ## Enabling debug logging
 
+Runtime file logs are stored in `<config>/pumplog/`. The files `pump.log` and `telemetry.json` are only written when the outdoor temperature is `10°C` or lower to reduce unnecessary disk I/O during warmer periods when heat-pump steering is normally not relevant.
+
 Add this to your `configuration.yaml` to get detailed PumpSteer logs:
 
 ```yaml

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,15 +1,22 @@
 """Shared pytest fixtures for PumpSteer tests."""
 
 import asyncio
+import sys
+from pathlib import Path
 
 import pytest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
 
 
 @pytest.fixture(autouse=True)
 def enable_event_loop_debug():
     """Provide a synchronous event loop fixture for Home Assistant test plugins."""
     try:
-        asyncio.get_event_loop()
+        asyncio.get_running_loop()
     except RuntimeError:
         loop = asyncio.new_event_loop()
         asyncio.set_event_loop(loop)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,31 +1,17 @@
+"""Shared pytest fixtures for PumpSteer tests."""
+
 import asyncio
-import sys
 
 import pytest
-from pathlib import Path
-
-# Lägg till projektrot (/config)
-sys.path.insert(0, str(Path(__file__).resolve().parents[3]))
-
-# Lägg till pumpsteer-mappen
-sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
-
-# 🔥 VIKTIGAST: ladda stubbar först
-import ha_test_stubs  # noqa: F401
 
 
 @pytest.fixture(autouse=True)
-def ensure_event_loop():
-    """Ensure sync tests have a current event loop."""
+def enable_event_loop_debug():
+    """Provide a synchronous event loop fixture for Home Assistant test plugins."""
     try:
-        asyncio.get_running_loop()
+        asyncio.get_event_loop()
     except RuntimeError:
         loop = asyncio.new_event_loop()
         asyncio.set_event_loop(loop)
-        try:
-            yield
-        finally:
-            loop.close()
-            asyncio.set_event_loop(None)
-    else:
-        yield
+
+    yield

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,7 @@
+import asyncio
 import sys
+
+import pytest
 from pathlib import Path
 
 # Lägg till projektrot (/config)
@@ -9,3 +12,20 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
 # 🔥 VIKTIGAST: ladda stubbar först
 import ha_test_stubs  # noqa: F401
+
+
+@pytest.fixture(autouse=True)
+def ensure_event_loop():
+    """Ensure sync tests have a current event loop."""
+    try:
+        asyncio.get_running_loop()
+    except RuntimeError:
+        loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(loop)
+        try:
+            yield
+        finally:
+            loop.close()
+            asyncio.set_event_loop(None)
+    else:
+        yield

--- a/tests/test_pump_log.py
+++ b/tests/test_pump_log.py
@@ -23,14 +23,17 @@ def teardown_function() -> None:
         pump_log._file_logger.removeHandler(handler)
 
 
-def test_setup_pump_log_uses_pumplog_directory_and_creates_it(tmp_path):
+def test_setup_pump_log_uses_pumplog_directory_and_creates_it_without_files(tmp_path):
     pump_log.setup_pump_log(DummyHass(tmp_path))
 
-    assert (tmp_path / pump_log.LOG_DIR_NAME).is_dir()
+    log_dir = tmp_path / pump_log.LOG_DIR_NAME
+    assert log_dir.is_dir()
     assert pump_log.LOG_DIR_NAME == "pumplog"
+    assert not (log_dir / "pump.log").exists()
+    assert not (log_dir / "telemetry.json").exists()
 
 
-def test_pump_log_written_when_outdoor_temperature_is_cold(tmp_path):
+def test_pump_log_written_when_real_outdoor_temperature_is_10(tmp_path):
     pump_log.setup_pump_log(DummyHass(tmp_path))
 
     pump_log.log_mode_change(None, "normal", 7.0, 20.0, 10.0, "normal", 1.0, 2.0)
@@ -42,7 +45,7 @@ def test_pump_log_written_when_outdoor_temperature_is_cold(tmp_path):
     assert "MODE ? → normal" in log_path.read_text(encoding="utf-8")
 
 
-def test_telemetry_written_when_outdoor_temperature_is_cold(tmp_path):
+def test_telemetry_written_when_real_outdoor_temperature_is_below_10(tmp_path):
     pump_log.setup_pump_log(DummyHass(tmp_path))
 
     pump_log.write_telemetry({"mode": "normal"}, 9.9)
@@ -52,12 +55,24 @@ def test_telemetry_written_when_outdoor_temperature_is_cold(tmp_path):
     assert json.loads(telemetry_path.read_text(encoding="utf-8")) == {"mode": "normal"}
 
 
-def test_runtime_files_not_updated_when_outdoor_temperature_is_warm(tmp_path):
+def test_runtime_files_not_created_when_real_outdoor_temperature_is_11(tmp_path):
+    pump_log.setup_pump_log(DummyHass(tmp_path))
+
+    pump_log.log_mode_change(None, "normal", 7.0, 20.0, 11.0, "normal", 1.0, 2.0)
+    pump_log.write_telemetry({"mode": "normal"}, 11.0)
+
+    assert not (tmp_path / "pumplog" / "pump.log").exists()
+    assert not (tmp_path / "pumplog" / "telemetry.json").exists()
+
+
+def test_runtime_files_not_updated_when_real_outdoor_temperature_is_warm(tmp_path):
     pump_log.setup_pump_log(DummyHass(tmp_path))
     log_path = tmp_path / "pumplog" / "pump.log"
     telemetry_path = tmp_path / "pumplog" / "telemetry.json"
     log_path.write_text("existing\n", encoding="utf-8")
     telemetry_path.write_text('{"old": true}\n', encoding="utf-8")
+    log_mtime = log_path.stat().st_mtime_ns
+    telemetry_mtime = telemetry_path.stat().st_mtime_ns
 
     pump_log.log_mode_change(None, "normal", 7.0, 20.0, 10.1, "normal", 1.0, 2.0)
     pump_log.write_telemetry({"mode": "normal"}, 10.1)
@@ -66,6 +81,26 @@ def test_runtime_files_not_updated_when_outdoor_temperature_is_warm(tmp_path):
 
     assert log_path.read_text(encoding="utf-8") == "existing\n"
     assert telemetry_path.read_text(encoding="utf-8") == '{"old": true}\n'
+    assert log_path.stat().st_mtime_ns == log_mtime
+    assert telemetry_path.stat().st_mtime_ns == telemetry_mtime
+
+
+def test_fake_output_temperature_below_10_does_not_write_when_real_outdoor_is_warm(
+    tmp_path,
+):
+    pump_log.setup_pump_log(DummyHass(tmp_path))
+
+    fake_output_temp = 5.0
+    real_outdoor_temp = 11.0
+    pump_log.log_mode_change(
+        None, "normal", fake_output_temp, 20.0, real_outdoor_temp, "normal", 1.0, 2.0
+    )
+    pump_log.write_telemetry(
+        {"fake_outdoor_temperature": fake_output_temp}, real_outdoor_temp
+    )
+
+    assert not (tmp_path / "pumplog" / "pump.log").exists()
+    assert not (tmp_path / "pumplog" / "telemetry.json").exists()
 
 
 def test_invalid_outdoor_temperatures_do_not_crash_or_write(tmp_path):
@@ -79,5 +114,55 @@ def test_invalid_outdoor_temperatures_do_not_crash_or_write(tmp_path):
     for handler in pump_log._file_logger.handlers:
         handler.flush()
 
-    assert log_path.read_text(encoding="utf-8") == ""
+    assert not log_path.exists()
     assert not (tmp_path / "pumplog" / "telemetry.json").exists()
+
+
+def test_set_state_uses_real_outdoor_temperature_for_runtime_log_gate(monkeypatch):
+    import asyncio
+    from datetime import datetime, timezone
+
+    from custom_components.pumpsteer import sensor as sensor_module
+    from custom_components.pumpsteer.sensor import PumpSteerSensor
+
+    class DummyEntry:
+        entry_id = "entry"
+        data = {}
+        options = {}
+
+        def add_update_listener(self, listener):
+            return None
+
+    captured = {}
+
+    def fake_log_mode_change(**kwargs):
+        captured["log_outdoor"] = kwargs["outdoor"]
+        captured["fake_temp"] = kwargs["fake_temp"]
+
+    def fake_write_telemetry(data, outdoor_temp):
+        captured["telemetry_outdoor"] = outdoor_temp
+        captured["telemetry_fake"] = data["fake_outdoor_temperature"]
+
+    async def fake_async_push_ohmigo(hass, config_entry, fake_temp, last_push):
+        return last_push
+
+    monkeypatch.setattr(sensor_module, "log_mode_change", fake_log_mode_change)
+    monkeypatch.setattr(sensor_module, "write_telemetry", fake_write_telemetry)
+    monkeypatch.setattr(sensor_module, "async_push_ohmigo", fake_async_push_ohmigo)
+
+    pump_sensor = PumpSteerSensor(DummyHass(Path("/tmp")), DummyEntry())
+    asyncio.run(
+        pump_sensor._set_state(
+            5.0,
+            "normal",
+            {"outdoor_temperature": 11.0, "indoor_temperature": 20.0},
+            datetime.now(timezone.utc),
+        )
+    )
+
+    assert captured == {
+        "log_outdoor": 11.0,
+        "fake_temp": 5.0,
+        "telemetry_outdoor": 11.0,
+        "telemetry_fake": 5.0,
+    }

--- a/tests/test_pump_log.py
+++ b/tests/test_pump_log.py
@@ -1,0 +1,83 @@
+import json
+from pathlib import Path
+
+from custom_components.pumpsteer import pump_log
+
+
+class DummyConfig:
+    def __init__(self, root: Path) -> None:
+        self.root = root
+
+    def path(self, *parts: str) -> str:
+        return str(self.root.joinpath(*parts))
+
+
+class DummyHass:
+    def __init__(self, root: Path) -> None:
+        self.config = DummyConfig(root)
+
+
+def teardown_function() -> None:
+    for handler in list(pump_log._file_logger.handlers):
+        handler.close()
+        pump_log._file_logger.removeHandler(handler)
+
+
+def test_setup_pump_log_uses_pumplog_directory_and_creates_it(tmp_path):
+    pump_log.setup_pump_log(DummyHass(tmp_path))
+
+    assert (tmp_path / pump_log.LOG_DIR_NAME).is_dir()
+    assert pump_log.LOG_DIR_NAME == "pumplog"
+
+
+def test_pump_log_written_when_outdoor_temperature_is_cold(tmp_path):
+    pump_log.setup_pump_log(DummyHass(tmp_path))
+
+    pump_log.log_mode_change(None, "normal", 7.0, 20.0, 10.0, "normal", 1.0, 2.0)
+    for handler in pump_log._file_logger.handlers:
+        handler.flush()
+
+    log_path = tmp_path / "pumplog" / "pump.log"
+    assert log_path.exists()
+    assert "MODE ? → normal" in log_path.read_text(encoding="utf-8")
+
+
+def test_telemetry_written_when_outdoor_temperature_is_cold(tmp_path):
+    pump_log.setup_pump_log(DummyHass(tmp_path))
+
+    pump_log.write_telemetry({"mode": "normal"}, 9.9)
+
+    telemetry_path = tmp_path / "pumplog" / "telemetry.json"
+    assert telemetry_path.exists()
+    assert json.loads(telemetry_path.read_text(encoding="utf-8")) == {"mode": "normal"}
+
+
+def test_runtime_files_not_updated_when_outdoor_temperature_is_warm(tmp_path):
+    pump_log.setup_pump_log(DummyHass(tmp_path))
+    log_path = tmp_path / "pumplog" / "pump.log"
+    telemetry_path = tmp_path / "pumplog" / "telemetry.json"
+    log_path.write_text("existing\n", encoding="utf-8")
+    telemetry_path.write_text('{"old": true}\n', encoding="utf-8")
+
+    pump_log.log_mode_change(None, "normal", 7.0, 20.0, 10.1, "normal", 1.0, 2.0)
+    pump_log.write_telemetry({"mode": "normal"}, 10.1)
+    for handler in pump_log._file_logger.handlers:
+        handler.flush()
+
+    assert log_path.read_text(encoding="utf-8") == "existing\n"
+    assert telemetry_path.read_text(encoding="utf-8") == '{"old": true}\n'
+
+
+def test_invalid_outdoor_temperatures_do_not_crash_or_write(tmp_path):
+    pump_log.setup_pump_log(DummyHass(tmp_path))
+    log_path = tmp_path / "pumplog" / "pump.log"
+
+    for invalid in ("unknown", "unavailable", None, "not-a-number"):
+        pump_log.log_event("EVENT", outdoor=invalid)
+        pump_log.write_telemetry({"invalid": invalid}, invalid)
+
+    for handler in pump_log._file_logger.handlers:
+        handler.flush()
+
+    assert log_path.read_text(encoding="utf-8") == ""
+    assert not (tmp_path / "pumplog" / "telemetry.json").exists()


### PR DESCRIPTION
### Motivation
- Avoid storing runtime files in a confusing `pumpsteer` runtime folder and place them under a clear `pumplog` directory inside Home Assistant config.
- Reduce unnecessary disk I/O by preventing `pump.log` and `telemetry.json` updates when heat-pump steering is not relevant (outdoor temperature > 10°C or unknown).
- Make the change minimal and safe: do not modify integration domain, module paths, entity IDs or control logic.

### Description
- Added constants and a new runtime logger module behavior in `custom_components/pumpsteer/pump_log.py` (`LOG_DIR_NAME`, `PUMP_LOG_FILE`, `TELEMETRY_FILE`, `LOGGING_OUTDOOR_TEMP_THRESHOLD_C`) and resolved the log path via `hass.config.path("pumplog")` when available, creating the directory with `Path.mkdir(..., exist_ok=True)`.
- Introduced helpers `_coerce_outdoor_temp()` and `_should_write_runtime_logs()` and applied the temperature gate so both `log_mode_change()`/`log_event()` and `write_telemetry()` skip disk writes when outdoor temperature is missing/invalid or `> 10°C`.
- Wired telemetry snapshot writing via a new `write_telemetry()` call in `custom_components/pumpsteer/sensor.py` after attributes are set, and made `async_setup_entry()` call `setup_pump_log(hass)` so the correct config path is used; logging calls were augmented to pass the available outdoor temperature so the same gate can be used consistently.
- Updated docs (`README.md`, `docs/TROUBLESHOOTING.md`, `docs/CHANGELOG.md`) to document that runtime logs are stored in `<config>/pumplog/` and are only written when outdoor temperature is `<= 10°C`, and added targeted tests in `tests/test_pump_log.py` covering directory creation, cold writes, warm skips and invalid outdoor values.
- No integration domain, entity IDs, control algorithms, or module/package names under `custom_components/pumpsteer` were changed.

### Testing
- Ran the full test suite with `python -m pytest` (all tests passed: `132 passed`).
- Ran static/format checks: `python -m ruff check` (passed) and `python -m ruff format --check` (passed after formatting changes).
- Ran `flake8` critical error check for the integration (`python -m flake8 custom_components/pumpsteer --select=E9,F63,F7,F82,F401`) which passed in the environment used for verification.
- Executed targeted tests `tests/test_pump_log.py` (5 tests) and confirmed they pass.
- Ran `git diff --check` and fixed minor formatting issues found; final verification commands all report success.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4752a7cbe8832e8646531c14667ef6)