### PR TITLE
Fix options flow being unsavable without a weather entity

### DIFF
--- a/custom_components/pumpsteer/options_flow.py
+++ b/custom_components/pumpsteer/options_flow.py
@@ -55,7 +55,9 @@ class PumpSteerOptionsFlowHandler(config_entries.OptionsFlow):
                     ),
                     vol.Optional(
                         "weather_entity",
-                        default=current_data.get("weather_entity"),
+                        description={
+                            "suggested_value": current_data.get("weather_entity")
+                        },
                     ): selector({"entity": {"domain": "weather"}}),
                     vol.Required(
                         "electricity_price_entity",


### PR DESCRIPTION
`vol.Optional("weather_entity", default=...)` inserts the default into `user_input` before validation. When no weather entity is configured the default is `None`, which the entity selector rejects:

```
{"errors": {"weather_entity": "Entity None is neither a valid entity ID nor a valid UUID"}}
```

Submitting an empty string fails the same way, so the field is optional in name only.

Because validation covers the whole form, this blocks saving **any** option — `notify_service`, `ohmigo_entity`, `modbus_service` — for users who have never set a weather entity.

### Reproduction

On 2.1.1 with no weather entity configured: Settings → Devices & Services → PumpSteer → Configure → Submit, without changing anything. The form refuses to save with the error above.

### Fix

Use `description={"suggested_value": ...}` instead of `default=`. The field is still prefilled with the current value, but nothing is inserted when it is left empty.

This matches how `config_flow.py` already declares the same field:

```python
vol.Optional("weather_entity"): selector({"entity": {"domain": "weather"}})
```

and what `_validate_entities` in the same file already assumes:

```python
# weather_entity is optional — validate only if set
weather = user_input.get("weather_entity")
if weather and not self._entity_exists(weather):
    errors["weather_entity"] = "entity_not_found"
```
