### PR TITLE
Fix 2.1.2 GOS/Modbus regression

### DIFF
--- a/custom_components/pumpsteer/ohmigo.py
+++ b/custom_components/pumpsteer/ohmigo.py
@@ -103,7 +103,9 @@ async def async_push_modbus(
             service_data,
             blocking=False,
         )
-        _LOGGER.debug("Generic output push: %s → fake_temp=%.1f °C", service_str, fake_temp)
+        _LOGGER.debug(
+            "Generic output push: %s → fake_temp=%.1f °C", service_str, fake_temp
+        )
         return now
     except Exception as err:
         _LOGGER.warning("Generic output push failed (%s): %s", service_str, err)

--- a/custom_components/pumpsteer/ohmigo.py
+++ b/custom_components/pumpsteer/ohmigo.py
@@ -1,4 +1,4 @@
-"""PumpSteer — Ohmigo setpoint push logic."""
+"""PumpSteer output push logic for Ohmigo and Generic Output System."""
 
 from __future__ import annotations
 
@@ -16,6 +16,14 @@ from .settings import OHMIGO_DEFAULT_INTERVAL_MINUTES, OHMIGO_HYSTERESIS_C
 
 _LOGGER = logging.getLogger(__name__)
 
+_MODBUS_DEFAULT_INTERVAL_MINUTES: float = 5.0
+
+# GOS used to keep its last-push timestamp in sensor.py. Version 2.1.2 lost
+# that runtime path together with the options fields. Keep the timestamp in
+# the output module for the hotfix so GOS remains independent from Ohmigo
+# timing without replacing or downgrading the current sensor implementation.
+_modbus_last_push_by_entry: dict[str, datetime] = {}
+
 
 def _switch_entity_id(hass: HomeAssistant, entry_id: str) -> Optional[str]:
     registry = er.async_get(hass)
@@ -32,12 +40,110 @@ def _ohmigo_push_enabled(hass: HomeAssistant, entry_id: str) -> bool:
     return state.state == "on"
 
 
+async def async_push_modbus(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    fake_temp: float,
+    last_push_time: Optional[datetime],
+) -> Optional[datetime]:
+    """Push fake_temp through a configurable Home Assistant service call."""
+    cfg = {**entry.data, **entry.options}
+    service_str: str = str(cfg.get("modbus_service", "")).strip()
+    if not service_str:
+        return last_push_time
+
+    interval_minutes: float = float(
+        cfg.get("modbus_interval_minutes", _MODBUS_DEFAULT_INTERVAL_MINUTES)
+    )
+    now = dt_util.now()
+    if last_push_time is not None:
+        elapsed = (now - last_push_time).total_seconds() / 60.0
+        if elapsed < interval_minutes:
+            return last_push_time
+
+    if "." not in service_str:
+        _LOGGER.warning(
+            "modbus_service '%s' is not valid (expected 'domain.service')", service_str
+        )
+        return last_push_time
+
+    domain, service = service_str.split(".", 1)
+
+    payload_template: str = str(cfg.get("modbus_payload_template", "")).strip()
+    if not payload_template:
+        _LOGGER.warning("modbus_service is set but modbus_payload_template is empty")
+        return last_push_time
+
+    try:
+        from homeassistant.helpers import template as template_helper
+
+        tmpl = template_helper.Template(payload_template, hass)
+        rendered = tmpl.async_render({"fake_temp": fake_temp})
+    except Exception as err:
+        _LOGGER.warning("modbus_payload_template render failed: %s", err)
+        return last_push_time
+
+    if isinstance(rendered, dict):
+        service_data = rendered
+    else:
+        try:
+            import yaml
+
+            service_data = yaml.safe_load(str(rendered))
+            if not isinstance(service_data, dict):
+                raise ValueError(f"Expected dict, got {type(service_data)}")
+        except Exception as err:
+            _LOGGER.warning("modbus_payload_template did not produce a dict: %s", err)
+            return last_push_time
+
+    try:
+        await hass.services.async_call(
+            domain,
+            service,
+            service_data,
+            blocking=False,
+        )
+        _LOGGER.debug("Generic output push: %s → fake_temp=%.1f °C", service_str, fake_temp)
+        return now
+    except Exception as err:
+        _LOGGER.warning("Generic output push failed (%s): %s", service_str, err)
+        return last_push_time
+
+
+async def _async_push_generic_output(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    fake_temp: float,
+) -> None:
+    """Run GOS independently from Ohmigo while keeping its own interval state."""
+    cfg = {**entry.data, **entry.options}
+    service_str = str(cfg.get("modbus_service", "")).strip()
+
+    if not service_str:
+        _modbus_last_push_by_entry.pop(entry.entry_id, None)
+        return
+
+    last_push_time = _modbus_last_push_by_entry.get(entry.entry_id)
+    updated_last_push = await async_push_modbus(
+        hass,
+        entry,
+        fake_temp,
+        last_push_time,
+    )
+    if updated_last_push is not None:
+        _modbus_last_push_by_entry[entry.entry_id] = updated_last_push
+
+
 async def async_push_ohmigo(
     hass: HomeAssistant,
     entry: ConfigEntry,
     fake_temp: float,
     last_push_time: Optional[datetime],
 ) -> Optional[datetime]:
+    """Push fake_temp to GOS and, when configured, to an Ohmigo number entity."""
+    # GOS is independent from Ohmigo and must run even if no Ohmigo entity is configured.
+    await _async_push_generic_output(hass, entry, fake_temp)
+
     cfg = {**entry.data, **entry.options}
     ohmigo_entity: str = cfg.get("ohmigo_entity", "")
     if not ohmigo_entity:

--- a/custom_components/pumpsteer/options_flow.py
+++ b/custom_components/pumpsteer/options_flow.py
@@ -103,6 +103,28 @@ class PumpSteerOptionsFlowHandler(config_entries.OptionsFlow):
                             }
                         }
                     ),
+                    vol.Optional(
+                        "modbus_service",
+                        default=current_data.get("modbus_service", ""),
+                    ): selector({"text": {}}),
+                    vol.Optional(
+                        "modbus_payload_template",
+                        default=current_data.get("modbus_payload_template", ""),
+                    ): selector({"text": {"multiline": True}}),
+                    vol.Optional(
+                        "modbus_interval_minutes",
+                        default=current_data.get("modbus_interval_minutes", 5),
+                    ): selector(
+                        {
+                            "number": {
+                                "min": 1,
+                                "max": 60,
+                                "step": 1,
+                                "unit_of_measurement": "min",
+                                "mode": "slider",
+                            }
+                        }
+                    ),
                 }
             ),
             errors=errors,

--- a/custom_components/pumpsteer/strings.json
+++ b/custom_components/pumpsteer/strings.json
@@ -39,7 +39,10 @@
           "min_brake_strength": "Minimum brake strength",
           "max_brake_strength": "Maximum brake strength",
           "experimental_ml_enabled": "Enable Experimental ML",
-          "price_tomorrow_entity": "Tomorrow electricity price sensor"
+          "price_tomorrow_entity": "Tomorrow electricity price sensor",
+          "modbus_service": "Generic output service",
+          "modbus_payload_template": "Generic output payload template",
+          "modbus_interval_minutes": "Generic output push interval"
         },
         "data_description": {
           "pid_kp": "How strongly PumpSteer reacts to current temperature error. Typical range: 2.0 to 5.0.",
@@ -50,7 +53,10 @@
           "pi_price_feedforward_gain": "How much the electricity price affects the pump before a temp drop occurs.",
           "brake_ramp_in_minutes": "How many minutes to transition from normal operation to full brake. Protects the compressor.",
           "experimental_ml_enabled": "Uses historical data to learn your house's thermal inertia automatically.",
-          "pid_kd": "How much PumpSteer reacts to fast temperature changes. Keep at 0.0 unless you tune it intentionally."
+          "pid_kd": "How much PumpSteer reacts to fast temperature changes. Keep at 0.0 unless you tune it intentionally.",
+          "modbus_service": "Home Assistant service to call, for example modbus.write_register, mqtt.publish or input_number.set_value.",
+          "modbus_payload_template": "YAML payload template for the service call. The template can use {{ fake_temp }}.",
+          "modbus_interval_minutes": "Minimum time between Generic Output System service calls."
         }
       }
     },

--- a/custom_components/pumpsteer/translations/en.json
+++ b/custom_components/pumpsteer/translations/en.json
@@ -33,7 +33,10 @@
           "notify_service": "Notification service (optional, e.g. notify.mobile_app_my_phone)",
           "preheat_boost_enabled": "Enable preheat boost",
           "ohmigo_entity": "Ohmigo setpoint entity (optional)",
-          "ohmigo_interval_minutes": "Ohmigo push interval"
+          "ohmigo_interval_minutes": "Ohmigo push interval",
+          "modbus_service": "Generic output service",
+          "modbus_payload_template": "Generic output payload template",
+          "modbus_interval_minutes": "Generic output push interval"
         },
         "data_description": {
           "pid_kp": "How strongly PumpSteer reacts to current temperature error. Typical range: 2.0 to 5.0.",
@@ -44,7 +47,10 @@
           "notify_service": "Leave empty to use persistent notifications in the HA sidebar instead.",
           "preheat_boost_enabled": "When enabled, PumpSteer heats extra before expensive periods to build up thermal mass.",
           "ohmigo_entity": "PumpSteer will push the fake outdoor temperature to this number entity after each update. Leave empty to disable. Toggle without reconfiguring using the 'Ohmigo Push' switch.",
-          "ohmigo_interval_minutes": "Minimum time between pushes to Ohmigo. Default 5 minutes. Pushes are also skipped when the change is less than 0.2 °C."
+          "ohmigo_interval_minutes": "Minimum time between pushes to Ohmigo. Default 5 minutes. Pushes are also skipped when the change is less than 0.2 °C.",
+          "modbus_service": "Home Assistant service to call, for example modbus.write_register, mqtt.publish or input_number.set_value.",
+          "modbus_payload_template": "YAML payload template for the service call. The template can use {{ fake_temp }}.",
+          "modbus_interval_minutes": "Minimum time between Generic Output System service calls."
         }
       }
     },

--- a/custom_components/pumpsteer/translations/se.json
+++ b/custom_components/pumpsteer/translations/se.json
@@ -34,7 +34,10 @@
           "notify_service": "Notifieringstjänst (valfri, t.ex. notify.mobile_app_min_telefon)",
           "preheat_boost_enabled": "Aktivera förvärmning",
           "ohmigo_entity": "Ohmigo-entitet (valfri)",
-          "ohmigo_interval_minutes": "Ohmigo push-intervall"
+          "ohmigo_interval_minutes": "Ohmigo push-intervall",
+          "modbus_service": "Generisk utgångstjänst",
+          "modbus_payload_template": "Mall för generisk utgångspayload",
+          "modbus_interval_minutes": "Intervall för generisk utgång"
         },
         "data_description": {
           "pid_kp": "Hur kraftigt PumpSteer reagerar på aktuell temperaturdifferens. Typiskt intervall: 2,0 till 5,0.",
@@ -45,7 +48,10 @@
           "notify_service": "Lämna tomt för att använda beständiga notifieringar i HA:s sidofält istället.",
           "preheat_boost_enabled": "När aktiverad värmer PumpSteer extra inför dyra perioder för att bygga upp termisk massa.",
           "ohmigo_entity": "PumpSteer skickar den virtuella utetemperaturen till den här entiteten efter varje uppdatering. Lämna tomt för att inaktivera. Slå av/på utan att konfigurera om via brytaren 'Ohmigo Push'.",
-          "ohmigo_interval_minutes": "Minsta tid mellan push-uppdateringar till Ohmigo. Standard 5 minuter. Push hoppas även över om förändringen är mindre än 0,2 °C."
+          "ohmigo_interval_minutes": "Minsta tid mellan push-uppdateringar till Ohmigo. Standard 5 minuter. Push hoppas även över om förändringen är mindre än 0,2 °C.",
+          "modbus_service": "Home Assistant-tjänsten som ska anropas, till exempel modbus.write_register, mqtt.publish eller input_number.set_value.",
+          "modbus_payload_template": "YAML-mall för tjänsteanropets payload. Mallen kan använda {{ fake_temp }}.",
+          "modbus_interval_minutes": "Minsta tid mellan anrop från Generic Output System."
         }
       }
     },

--- a/tests/test_gos_regression.py
+++ b/tests/test_gos_regression.py
@@ -1,0 +1,114 @@
+import asyncio
+from pathlib import Path
+
+from custom_components.pumpsteer import ohmigo
+
+
+class _FakeServices:
+    def __init__(self):
+        self.calls = []
+
+    async def async_call(self, domain, service, data, blocking=False):
+        self.calls.append(
+            {
+                "domain": domain,
+                "service": service,
+                "data": data,
+                "blocking": blocking,
+            }
+        )
+
+
+class _FakeHass:
+    def __init__(self):
+        self.services = _FakeServices()
+
+
+class _FakeEntry:
+    def __init__(self, options):
+        self.entry_id = "test-entry"
+        self.data = {}
+        self.options = options
+
+
+class _FakeTemplate:
+    def __init__(self, template_text, hass):
+        self.template_text = template_text
+        self.hass = hass
+
+    def async_render(self, variables):
+        return {"value": round(variables["fake_temp"], 1)}
+
+
+def test_gos_options_fields_are_exposed():
+    """Keep all legacy GOS option keys visible in the options flow."""
+    source = Path("custom_components/pumpsteer/options_flow.py").read_text()
+
+    assert '"modbus_service"' in source
+    assert '"modbus_payload_template"' in source
+    assert '"modbus_interval_minutes"' in source
+    assert '"suggested_value": current_data.get("weather_entity")' in source
+
+
+def test_async_push_modbus_calls_configured_service(monkeypatch):
+    """Render fake_temp and forward the resulting mapping to the HA service."""
+    template_module = __import__(
+        "homeassistant.helpers.template", fromlist=["Template"]
+    )
+    monkeypatch.setattr(template_module, "Template", _FakeTemplate, raising=False)
+
+    hass = _FakeHass()
+    entry = _FakeEntry(
+        {
+            "modbus_service": "modbus.write_register",
+            "modbus_payload_template": 'value: "{{ fake_temp }}"',
+            "modbus_interval_minutes": 5,
+        }
+    )
+
+    last_push = asyncio.run(
+        ohmigo.async_push_modbus(hass, entry, 7.26, last_push_time=None)
+    )
+
+    assert last_push is not None
+    assert hass.services.calls == [
+        {
+            "domain": "modbus",
+            "service": "write_register",
+            "data": {"value": 7.3},
+            "blocking": False,
+        }
+    ]
+
+
+def test_gos_runs_without_ohmigo_entity(monkeypatch):
+    """GOS must run independently when no Ohmigo output is configured."""
+    template_module = __import__(
+        "homeassistant.helpers.template", fromlist=["Template"]
+    )
+    monkeypatch.setattr(template_module, "Template", _FakeTemplate, raising=False)
+
+    ohmigo._modbus_last_push_by_entry.clear()
+    hass = _FakeHass()
+    entry = _FakeEntry(
+        {
+            "ohmigo_entity": "",
+            "modbus_service": "input_number.set_value",
+            "modbus_payload_template": 'value: "{{ fake_temp }}"',
+            "modbus_interval_minutes": 5,
+        }
+    )
+
+    ohmigo_last_push = asyncio.run(
+        ohmigo.async_push_ohmigo(hass, entry, -3.44, last_push_time=None)
+    )
+
+    assert ohmigo_last_push is None
+    assert hass.services.calls == [
+        {
+            "domain": "input_number",
+            "service": "set_value",
+            "data": {"value": -3.4},
+            "blocking": False,
+        }
+    ]


### PR DESCRIPTION
## Summary

Fixes #248.

PumpSteer 2.1.2 was released from `main`, where the Generic Output System (GOS) runtime/options path from 2.1.1 was missing. This caused the Modbus/generic payload template field to disappear and generic output calls to stop running.

## Changes

- restore `modbus_service`, `modbus_payload_template` and `modbus_interval_minutes` in the options flow
- keep the 2.1.2 optional-weather fix using `suggested_value`
- restore `async_push_modbus()` / Generic Output System service calls
- run GOS independently of Ohmigo, including when no `ohmigo_entity` is configured
- keep GOS and Ohmigo interval state independent
- add English and Swedish UI labels/descriptions for GOS
- add regression tests for the options fields, payload rendering/service call, and GOS operation without Ohmigo

## Scope

No PI, price classification, braking, forecast or thermal-control logic is changed. The current `sensor.py` is intentionally kept intact rather than replacing it with the divergent 2.1.1 branch version.